### PR TITLE
fix: rename variable in generated test methods to avoid field name collision

### DIFF
--- a/gapic-generator/templates/default/service/rest/test/method/_normal.text.erb
+++ b/gapic-generator/templates/default/service/rest/test/method/_normal.text.erb
@@ -22,34 +22,34 @@ def test_<%= method.name %>
   <%= method.service.rest.service_name_full %>::<%= method.service.rest.service_stub_name %>.stub :<%= method.rest.transcoding_helper_name %>, ["", "", {}] do
     Gapic::Rest::ClientStub.stub :new, <%= method.name %>_client_stub do
       # Create client
-      client = <%= full_client_name %>.new do |config|
+      client_stub = <%= full_client_name %>.new do |config|
         config.credentials = :dummy_value
       end
 
       # Use hash object
-      client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
+      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       <%- if fields.any? -%>
       # Use named arguments
-      client.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
+      client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       <%- end -%>
       # Use protobuf object
-      client.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
+      client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       # Use hash object with options
-      client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
+      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       # Use protobuf object with options
-      client.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
+      client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 

--- a/gapic-generator/templates/default/service/rest/test/method/_normal.text.erb
+++ b/gapic-generator/templates/default/service/rest/test/method/_normal.text.erb
@@ -22,34 +22,34 @@ def test_<%= method.name %>
   <%= method.service.rest.service_name_full %>::<%= method.service.rest.service_stub_name %>.stub :<%= method.rest.transcoding_helper_name %>, ["", "", {}] do
     Gapic::Rest::ClientStub.stub :new, <%= method.name %>_client_stub do
       # Create client
-      client_stub = <%= full_client_name %>.new do |config|
+      c = <%= full_client_name %>.new do |config|
         config.credentials = :dummy_value
       end
 
       # Use hash object
-      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
+      c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       <%- if fields.any? -%>
       # Use named arguments
-      client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
+      c.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       <%- end -%>
       # Use protobuf object
-      client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
+      c.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       # Use hash object with options
-      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
+      c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 
       # Use protobuf object with options
-      client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
+      c.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end
 

--- a/gapic-generator/templates/default/service/rest/test/method/_server.text.erb
+++ b/gapic-generator/templates/default/service/rest/test/method/_server.text.erb
@@ -22,34 +22,34 @@ def test_<%= method.name %>
   <%= method.service.rest.service_name_full %>::<%= method.service.rest.service_stub_name %>.stub :<%= method.rest.transcoding_helper_name %>, ["", "", {}] do
     Gapic::Rest::ClientStub.stub :new, <%= method.name %>_client_stub do
       # Create client
-      client = <%= full_client_name %>.new do |config|
+      client_stub = <%= full_client_name %>.new do |config|
         config.credentials = :dummy_value
       end
 
       # Use hash object
-      client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
+      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       <%- if fields.any? -%>
       # Use named arguments
-      client.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
+      client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       <%- end -%>
       # Use protobuf object
-      client.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
+      client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       # Use hash object with options
-      client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
+      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       # Use protobuf object with options
-      client.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
+      client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 

--- a/gapic-generator/templates/default/service/rest/test/method/_server.text.erb
+++ b/gapic-generator/templates/default/service/rest/test/method/_server.text.erb
@@ -22,34 +22,34 @@ def test_<%= method.name %>
   <%= method.service.rest.service_name_full %>::<%= method.service.rest.service_stub_name %>.stub :<%= method.rest.transcoding_helper_name %>, ["", "", {}] do
     Gapic::Rest::ClientStub.stub :new, <%= method.name %>_client_stub do
       # Create client
-      client_stub = <%= full_client_name %>.new do |config|
+      c = <%= full_client_name %>.new do |config|
         config.credentials = :dummy_value
       end
 
       # Use hash object
-      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
+      c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       <%- if fields.any? -%>
       # Use named arguments
-      client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
+      c.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       <%- end -%>
       # Use protobuf object
-      client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
+      c.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       # Use hash object with options
-      client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
+      c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 
       # Use protobuf object with options
-      client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
+      c.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), call_options) do |_result, response|
         <%= indent_tail render(partial: "service/rest/test/method/assert_response", locals: { method: method }), 6 %>
       end.first
 

--- a/gapic-generator/templates/default/service/test/method/_bidi.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_bidi.text.erb
@@ -22,7 +22,7 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client_stub = <%= full_client_name %>.new do |config|
+    c = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
@@ -30,7 +30,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client_stub.<%= method.name %> enum_input do |response, operation|
+    c.<%= method.name %> enum_input do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -42,7 +42,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client_stub.<%= method.name %> stream_input do |response, operation|
+    c.<%= method.name %> stream_input do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -57,7 +57,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client_stub.<%= method.name %> enum_input, grpc_options do |response, operation|
+    c.<%= method.name %> enum_input, grpc_options do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -69,7 +69,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client_stub.<%= method.name %> stream_input, grpc_options do |response, operation|
+    c.<%= method.name %> stream_input, grpc_options do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r

--- a/gapic-generator/templates/default/service/test/method/_bidi.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_bidi.text.erb
@@ -22,7 +22,7 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client = <%= full_client_name %>.new do |config|
+    client_stub = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
@@ -30,7 +30,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client.<%= method.name %> enum_input do |response, operation|
+    client_stub.<%= method.name %> enum_input do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -42,7 +42,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client.<%= method.name %> stream_input do |response, operation|
+    client_stub.<%= method.name %> stream_input do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -57,7 +57,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client.<%= method.name %> enum_input, grpc_options do |response, operation|
+    client_stub.<%= method.name %> enum_input, grpc_options do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -69,7 +69,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client.<%= method.name %> stream_input, grpc_options do |response, operation|
+    client_stub.<%= method.name %> stream_input, grpc_options do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r

--- a/gapic-generator/templates/default/service/test/method/_client.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_client.text.erb
@@ -22,7 +22,7 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client = <%= full_client_name %>.new do |config|
+    client_stub = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
@@ -30,7 +30,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client.<%= method.name %> enum_input do |response, operation|
+    client_stub.<%= method.name %> enum_input do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
@@ -38,7 +38,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client.<%= method.name %> stream_input do |response, operation|
+    client_stub.<%= method.name %> stream_input do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
     stream_input << request_hash
@@ -49,7 +49,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client.<%= method.name %> enum_input, grpc_options do |response, operation|
+    client_stub.<%= method.name %> enum_input, grpc_options do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
@@ -57,7 +57,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client.<%= method.name %> stream_input, grpc_options do |response, operation|
+    client_stub.<%= method.name %> stream_input, grpc_options do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
     stream_input << request_hash

--- a/gapic-generator/templates/default/service/test/method/_client.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_client.text.erb
@@ -22,7 +22,7 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client_stub = <%= full_client_name %>.new do |config|
+    c = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
@@ -30,7 +30,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client_stub.<%= method.name %> enum_input do |response, operation|
+    c.<%= method.name %> enum_input do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
@@ -38,7 +38,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client_stub.<%= method.name %> stream_input do |response, operation|
+    c.<%= method.name %> stream_input do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
     stream_input << request_hash
@@ -49,7 +49,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     enum_input = [request_hash, request_proto].to_enum
-    client_stub.<%= method.name %> enum_input, grpc_options do |response, operation|
+    c.<%= method.name %> enum_input, grpc_options do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
@@ -57,7 +57,7 @@ def test_<%= method.name %>
     request_hash = { <%= fields.map(&:as_kwarg).join ", " %> }
     request_proto = <%= method.request_type %>.new <%= fields.map(&:as_kwarg).join ", " %>
     stream_input = Gapic::StreamInput.new
-    client_stub.<%= method.name %> stream_input, grpc_options do |response, operation|
+    c.<%= method.name %> stream_input, grpc_options do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
     stream_input << request_hash

--- a/gapic-generator/templates/default/service/test/method/_normal.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.text.erb
@@ -38,34 +38,34 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client_stub = <%= full_client_name %>.new do |config|
+    c = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
     # Use hash object
-    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
+    c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     <%- if fields.any? -%>
     # Use named arguments
-    client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
+    c.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     <%- end -%>
     # Use protobuf object
-    client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
+    c.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     # Use hash object with options
-    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
+    c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     # Use protobuf object with options
-    client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
+    c.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 

--- a/gapic-generator/templates/default/service/test/method/_normal.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.text.erb
@@ -38,34 +38,34 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client = <%= full_client_name %>.new do |config|
+    client_stub = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
     # Use hash object
-    client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
+    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     <%- if fields.any? -%>
     # Use named arguments
-    client.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
+    client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     <%- end -%>
     # Use protobuf object
-    client.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
+    client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     # Use hash object with options
-    client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
+    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 
     # Use protobuf object with options
-    client.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
+    client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 

--- a/gapic-generator/templates/default/service/test/method/_server.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_server.text.erb
@@ -38,12 +38,12 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client = <%= full_client_name %>.new do |config|
+    client_stub = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
     # Use hash object
-    client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
+    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -52,7 +52,7 @@ def test_<%= method.name %>
     end
 
     # Use named arguments
-    client.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
+    client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -61,7 +61,7 @@ def test_<%= method.name %>
     end
 
     # Use protobuf object
-    client.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
+    client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -70,7 +70,7 @@ def test_<%= method.name %>
     end
 
     # Use hash object with options
-    client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
+    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -79,7 +79,7 @@ def test_<%= method.name %>
     end
 
     # Use protobuf object with options
-    client.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
+    client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r

--- a/gapic-generator/templates/default/service/test/method/_server.text.erb
+++ b/gapic-generator/templates/default/service/test/method/_server.text.erb
@@ -38,12 +38,12 @@ def test_<%= method.name %>
 
   Gapic::ServiceStub.stub :new, <%= method.name %>_client_stub do
     # Create client
-    client_stub = <%= full_client_name %>.new do |config|
+    c = <%= full_client_name %>.new do |config|
       config.credentials = grpc_channel
     end
 
     # Use hash object
-    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
+    c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -52,7 +52,7 @@ def test_<%= method.name %>
     end
 
     # Use named arguments
-    client_stub.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
+    c.<%= method.name %> <%= fields.map(&:as_kwarg).join ", " %> do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -61,7 +61,7 @@ def test_<%= method.name %>
     end
 
     # Use protobuf object
-    client_stub.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
+    c.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -70,7 +70,7 @@ def test_<%= method.name %>
     end
 
     # Use hash object with options
-    client_stub.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
+    c.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }, grpc_options) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r
@@ -79,7 +79,7 @@ def test_<%= method.name %>
     end
 
     # Use protobuf object with options
-    client_stub.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
+    c.<%= method.name %>(<%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options) do |response, operation|
       assert_kind_of Enumerable, response
       response.to_a.each do |r|
         assert_kind_of <%= method.return_type %>, r

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_rest_test.rb
@@ -103,32 +103,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_aggregated_list_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, aggregated_list_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }) do |_result, response|
+        client_stub.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.aggregated_list filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success do |_result, response|
+        client_stub.aggregated_list filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.aggregated_list ::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success) do |_result, response|
+        client_stub.aggregated_list ::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        client_stub.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.aggregated_list(::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success), call_options) do |_result, response|
+        client_stub.aggregated_list(::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -160,32 +160,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_delete_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete({ address: address, project: project, region: region, request_id: request_id }) do |_result, response|
+        client_stub.delete({ address: address, project: project, region: region, request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete address: address, project: project, region: region, request_id: request_id do |_result, response|
+        client_stub.delete address: address, project: project, region: region, request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete ::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id) do |_result, response|
+        client_stub.delete ::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete({ address: address, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
+        client_stub.delete({ address: address, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete(::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id), call_options) do |_result, response|
+        client_stub.delete(::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -216,32 +216,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get({ address: address, project: project, region: region }) do |_result, response|
+        client_stub.get({ address: address, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get address: address, project: project, region: region do |_result, response|
+        client_stub.get address: address, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get ::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region) do |_result, response|
+        client_stub.get ::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get({ address: address, project: project, region: region }, call_options) do |_result, response|
+        client_stub.get({ address: address, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get(::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region), call_options) do |_result, response|
+        client_stub.get(::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -273,32 +273,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_insert_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, insert_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }) do |_result, response|
+        client_stub.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.insert address_resource: address_resource, project: project, region: region, request_id: request_id do |_result, response|
+        client_stub.insert address_resource: address_resource, project: project, region: region, request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.insert ::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id) do |_result, response|
+        client_stub.insert ::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
+        client_stub.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.insert(::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id), call_options) do |_result, response|
+        client_stub.insert(::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -333,32 +333,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_list_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
+        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
+        client_stub.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list ::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
+        client_stub.list ::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list(::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
+        client_stub.list(::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_rest_test.rb
@@ -103,32 +103,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_aggregated_list_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, aggregated_list_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }) do |_result, response|
+        c.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.aggregated_list filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success do |_result, response|
+        c.aggregated_list filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.aggregated_list ::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success) do |_result, response|
+        c.aggregated_list ::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        c.aggregated_list({ filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.aggregated_list(::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success), call_options) do |_result, response|
+        c.aggregated_list(::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new(filter: filter, include_all_scopes: include_all_scopes, max_results: max_results, order_by: order_by, page_token: page_token, project: project, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -160,32 +160,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_delete_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete({ address: address, project: project, region: region, request_id: request_id }) do |_result, response|
+        c.delete({ address: address, project: project, region: region, request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete address: address, project: project, region: region, request_id: request_id do |_result, response|
+        c.delete address: address, project: project, region: region, request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete ::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id) do |_result, response|
+        c.delete ::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete({ address: address, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
+        c.delete({ address: address, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete(::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id), call_options) do |_result, response|
+        c.delete(::Google::Cloud::Compute::V1::DeleteAddressRequest.new(address: address, project: project, region: region, request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -216,32 +216,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get({ address: address, project: project, region: region }) do |_result, response|
+        c.get({ address: address, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get address: address, project: project, region: region do |_result, response|
+        c.get address: address, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get ::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region) do |_result, response|
+        c.get ::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get({ address: address, project: project, region: region }, call_options) do |_result, response|
+        c.get({ address: address, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get(::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region), call_options) do |_result, response|
+        c.get(::Google::Cloud::Compute::V1::GetAddressRequest.new(address: address, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -273,32 +273,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_insert_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, insert_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }) do |_result, response|
+        c.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.insert address_resource: address_resource, project: project, region: region, request_id: request_id do |_result, response|
+        c.insert address_resource: address_resource, project: project, region: region, request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.insert ::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id) do |_result, response|
+        c.insert ::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
+        c.insert({ address_resource: address_resource, project: project, region: region, request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.insert(::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id), call_options) do |_result, response|
+        c.insert(::Google::Cloud::Compute::V1::InsertAddressRequest.new(address_resource: address_resource, project: project, region: region, request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -333,32 +333,32 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Addresses::Rest::ServiceStub.stub :transcode_list_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
+        c.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
+        c.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list ::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
+        c.list ::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        c.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list(::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
+        c.list(::Google::Cloud::Compute::V1::ListAddressesRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_rest_test.rb
@@ -98,32 +98,32 @@ class ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ServiceStub.stub :transcode_delete_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete({ operation: operation, project: project }) do |_result, response|
+        c.delete({ operation: operation, project: project }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete operation: operation, project: project do |_result, response|
+        c.delete operation: operation, project: project do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete ::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
+        c.delete ::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete({ operation: operation, project: project }, call_options) do |_result, response|
+        c.delete({ operation: operation, project: project }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete(::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
+        c.delete(::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -153,32 +153,32 @@ class ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get({ operation: operation, project: project }) do |_result, response|
+        c.get({ operation: operation, project: project }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get operation: operation, project: project do |_result, response|
+        c.get operation: operation, project: project do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get ::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
+        c.get ::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get({ operation: operation, project: project }, call_options) do |_result, response|
+        c.get({ operation: operation, project: project }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get(::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
+        c.get(::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_rest_test.rb
@@ -98,32 +98,32 @@ class ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ServiceStub.stub :transcode_delete_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete({ operation: operation, project: project }) do |_result, response|
+        client_stub.delete({ operation: operation, project: project }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete operation: operation, project: project do |_result, response|
+        client_stub.delete operation: operation, project: project do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete ::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
+        client_stub.delete ::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete({ operation: operation, project: project }, call_options) do |_result, response|
+        client_stub.delete({ operation: operation, project: project }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete(::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
+        client_stub.delete(::Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -153,32 +153,32 @@ class ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get({ operation: operation, project: project }) do |_result, response|
+        client_stub.get({ operation: operation, project: project }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get operation: operation, project: project do |_result, response|
+        client_stub.get operation: operation, project: project do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get ::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
+        client_stub.get ::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get({ operation: operation, project: project }, call_options) do |_result, response|
+        client_stub.get({ operation: operation, project: project }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get(::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
+        client_stub.get(::Google::Cloud::Compute::V1::GetGlobalOperationRequest.new(operation: operation, project: project), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_rest_test.rb
@@ -106,32 +106,32 @@ class ::Google::Cloud::Compute::V1::Networks::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Networks::Rest::ServiceStub.stub :transcode_list_peering_routes_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_peering_routes_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
+        c.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_peering_routes direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
+        c.list_peering_routes direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_peering_routes ::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
+        c.list_peering_routes ::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        c.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_peering_routes(::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
+        c.list_peering_routes(::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -163,32 +163,32 @@ class ::Google::Cloud::Compute::V1::Networks::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Networks::Rest::ServiceStub.stub :transcode_remove_peering_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, remove_peering_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }) do |_result, response|
+        c.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.remove_peering network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id do |_result, response|
+        c.remove_peering network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.remove_peering ::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id) do |_result, response|
+        c.remove_peering ::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }, call_options) do |_result, response|
+        c.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.remove_peering(::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id), call_options) do |_result, response|
+        c.remove_peering(::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_rest_test.rb
@@ -106,32 +106,32 @@ class ::Google::Cloud::Compute::V1::Networks::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Networks::Rest::ServiceStub.stub :transcode_list_peering_routes_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_peering_routes_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
+        client_stub.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_peering_routes direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
+        client_stub.list_peering_routes direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_peering_routes ::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
+        client_stub.list_peering_routes ::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        client_stub.list_peering_routes({ direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_peering_routes(::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
+        client_stub.list_peering_routes(::Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new(direction: direction, filter: filter, max_results: max_results, network: network, order_by: order_by, page_token: page_token, peering_name: peering_name, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -163,32 +163,32 @@ class ::Google::Cloud::Compute::V1::Networks::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Compute::V1::Networks::Rest::ServiceStub.stub :transcode_remove_peering_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, remove_peering_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::Networks::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }) do |_result, response|
+        client_stub.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.remove_peering network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id do |_result, response|
+        client_stub.remove_peering network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.remove_peering ::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id) do |_result, response|
+        client_stub.remove_peering ::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }, call_options) do |_result, response|
+        client_stub.remove_peering({ network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.remove_peering(::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id), call_options) do |_result, response|
+        client_stub.remove_peering(::Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new(network: network, networks_remove_peering_request_resource: networks_remove_peering_request_resource, project: project, request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_rest_test.rb
@@ -101,32 +101,32 @@ class ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::ClientTes
     ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::ServiceStub.stub :transcode_resize_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, resize_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }) do |_result, response|
+        client_stub.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.resize instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size do |_result, response|
+        client_stub.resize instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.resize ::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size) do |_result, response|
+        client_stub.resize ::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }, call_options) do |_result, response|
+        client_stub.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.resize(::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size), call_options) do |_result, response|
+        client_stub.resize(::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_rest_test.rb
@@ -101,32 +101,32 @@ class ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::ClientTes
     ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::ServiceStub.stub :transcode_resize_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, resize_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }) do |_result, response|
+        c.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.resize instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size do |_result, response|
+        c.resize instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.resize ::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size) do |_result, response|
+        c.resize ::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }, call_options) do |_result, response|
+        c.resize({ instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.resize(::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size), call_options) do |_result, response|
+        c.resize(::Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new(instance_group_manager: instance_group_manager, project: project, region: region, request_id: request_id, size: size), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_delete_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete({ operation: operation, project: project, region: region }) do |_result, response|
+        c.delete({ operation: operation, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete operation: operation, project: project, region: region do |_result, response|
+        c.delete operation: operation, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete ::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
+        c.delete ::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete({ operation: operation, project: project, region: region }, call_options) do |_result, response|
+        c.delete({ operation: operation, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete(::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
+        c.delete(::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get({ operation: operation, project: project, region: region }) do |_result, response|
+        c.get({ operation: operation, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get operation: operation, project: project, region: region do |_result, response|
+        c.get operation: operation, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get ::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
+        c.get ::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get({ operation: operation, project: project, region: region }, call_options) do |_result, response|
+        c.get({ operation: operation, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get(::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
+        c.get(::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -215,32 +215,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_list_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
+        c.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
+        c.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list ::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
+        c.list ::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        c.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list(::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
+        c.list(::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -271,32 +271,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_wait_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, wait_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.wait({ operation: operation, project: project, region: region }) do |_result, response|
+        c.wait({ operation: operation, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.wait operation: operation, project: project, region: region do |_result, response|
+        c.wait operation: operation, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.wait ::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
+        c.wait ::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.wait({ operation: operation, project: project, region: region }, call_options) do |_result, response|
+        c.wait({ operation: operation, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.wait(::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
+        c.wait(::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_delete_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete({ operation: operation, project: project, region: region }) do |_result, response|
+        client_stub.delete({ operation: operation, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete operation: operation, project: project, region: region do |_result, response|
+        client_stub.delete operation: operation, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete ::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
+        client_stub.delete ::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete({ operation: operation, project: project, region: region }, call_options) do |_result, response|
+        client_stub.delete({ operation: operation, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete(::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
+        client_stub.delete(::Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get({ operation: operation, project: project, region: region }) do |_result, response|
+        client_stub.get({ operation: operation, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get operation: operation, project: project, region: region do |_result, response|
+        client_stub.get operation: operation, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get ::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
+        client_stub.get ::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get({ operation: operation, project: project, region: region }, call_options) do |_result, response|
+        client_stub.get({ operation: operation, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get(::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
+        client_stub.get(::Google::Cloud::Compute::V1::GetRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -215,32 +215,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_list_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
+        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
+        client_stub.list filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list ::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
+        client_stub.list ::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
+        client_stub.list({ filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list(::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
+        client_stub.list(::Google::Cloud::Compute::V1::ListRegionOperationsRequest.new(filter: filter, max_results: max_results, order_by: order_by, page_token: page_token, project: project, region: region, return_partial_success: return_partial_success), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -271,32 +271,32 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     ::Google::Cloud::Compute::V1::RegionOperations::Rest::ServiceStub.stub :transcode_wait_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, wait_client_stub do
         # Create client
-        client = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.wait({ operation: operation, project: project, region: region }) do |_result, response|
+        client_stub.wait({ operation: operation, project: project, region: region }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.wait operation: operation, project: project, region: region do |_result, response|
+        client_stub.wait operation: operation, project: project, region: region do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.wait ::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
+        client_stub.wait ::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.wait({ operation: operation, project: project, region: region }, call_options) do |_result, response|
+        client_stub.wait({ operation: operation, project: project, region: region }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.wait(::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
+        client_stub.wait(::Google::Cloud::Compute::V1::WaitRegionOperationRequest.new(operation: operation, project: project, region: region), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
+++ b/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
@@ -82,36 +82,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_occurrence_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_occurrence({ name: name }) do |response, operation|
+      client_stub.get_occurrence({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_occurrence name: name do |response, operation|
+      client_stub.get_occurrence name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_occurrence ::Grafeas::V1::GetOccurrenceRequest.new(name: name) do |response, operation|
+      client_stub.get_occurrence ::Grafeas::V1::GetOccurrenceRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_occurrence({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_occurrence({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_occurrence(::Grafeas::V1::GetOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_occurrence(::Grafeas::V1::GetOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -146,40 +146,40 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_occurrences_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_occurrences parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_occurrences parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_occurrences ::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_occurrences ::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_occurrences(::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_occurrences(::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -209,36 +209,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_occurrence_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_occurrence({ name: name }) do |response, operation|
+      client_stub.delete_occurrence({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_occurrence name: name do |response, operation|
+      client_stub.delete_occurrence name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_occurrence ::Grafeas::V1::DeleteOccurrenceRequest.new(name: name) do |response, operation|
+      client_stub.delete_occurrence ::Grafeas::V1::DeleteOccurrenceRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_occurrence({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_occurrence({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_occurrence(::Grafeas::V1::DeleteOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_occurrence(::Grafeas::V1::DeleteOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -269,36 +269,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_occurrence_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_occurrence({ parent: parent, occurrence: occurrence }) do |response, operation|
+      client_stub.create_occurrence({ parent: parent, occurrence: occurrence }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_occurrence parent: parent, occurrence: occurrence do |response, operation|
+      client_stub.create_occurrence parent: parent, occurrence: occurrence do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_occurrence ::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence) do |response, operation|
+      client_stub.create_occurrence ::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_occurrence({ parent: parent, occurrence: occurrence }, grpc_options) do |response, operation|
+      client_stub.create_occurrence({ parent: parent, occurrence: occurrence }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_occurrence(::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence), grpc_options) do |response, operation|
+      client_stub.create_occurrence(::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_create_occurrences_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.batch_create_occurrences({ parent: parent, occurrences: occurrences }) do |response, operation|
+      client_stub.batch_create_occurrences({ parent: parent, occurrences: occurrences }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.batch_create_occurrences parent: parent, occurrences: occurrences do |response, operation|
+      client_stub.batch_create_occurrences parent: parent, occurrences: occurrences do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.batch_create_occurrences ::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences) do |response, operation|
+      client_stub.batch_create_occurrences ::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.batch_create_occurrences({ parent: parent, occurrences: occurrences }, grpc_options) do |response, operation|
+      client_stub.batch_create_occurrences({ parent: parent, occurrences: occurrences }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.batch_create_occurrences(::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences), grpc_options) do |response, operation|
+      client_stub.batch_create_occurrences(::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,36 +391,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_occurrence_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }) do |response, operation|
+      client_stub.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_occurrence name: name, occurrence: occurrence, update_mask: update_mask do |response, operation|
+      client_stub.update_occurrence name: name, occurrence: occurrence, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_occurrence ::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask) do |response, operation|
+      client_stub.update_occurrence ::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_occurrence(::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_occurrence(::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -449,36 +449,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_occurrence_note_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_occurrence_note({ name: name }) do |response, operation|
+      client_stub.get_occurrence_note({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_occurrence_note name: name do |response, operation|
+      client_stub.get_occurrence_note name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_occurrence_note ::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name) do |response, operation|
+      client_stub.get_occurrence_note ::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_occurrence_note({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_occurrence_note({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_occurrence_note(::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_occurrence_note(::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -507,36 +507,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_note_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_note({ name: name }) do |response, operation|
+      client_stub.get_note({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_note name: name do |response, operation|
+      client_stub.get_note name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_note ::Grafeas::V1::GetNoteRequest.new(name: name) do |response, operation|
+      client_stub.get_note ::Grafeas::V1::GetNoteRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_note({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_note({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_note(::Grafeas::V1::GetNoteRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_note(::Grafeas::V1::GetNoteRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -571,40 +571,40 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_notes_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_notes parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_notes parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_notes ::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_notes ::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_notes(::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_notes(::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -634,36 +634,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_note_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_note({ name: name }) do |response, operation|
+      client_stub.delete_note({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_note name: name do |response, operation|
+      client_stub.delete_note name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_note ::Grafeas::V1::DeleteNoteRequest.new(name: name) do |response, operation|
+      client_stub.delete_note ::Grafeas::V1::DeleteNoteRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_note({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_note({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_note(::Grafeas::V1::DeleteNoteRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_note(::Grafeas::V1::DeleteNoteRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -696,36 +696,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_note_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_note({ parent: parent, note_id: note_id, note: note }) do |response, operation|
+      client_stub.create_note({ parent: parent, note_id: note_id, note: note }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_note parent: parent, note_id: note_id, note: note do |response, operation|
+      client_stub.create_note parent: parent, note_id: note_id, note: note do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_note ::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note) do |response, operation|
+      client_stub.create_note ::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_note({ parent: parent, note_id: note_id, note: note }, grpc_options) do |response, operation|
+      client_stub.create_note({ parent: parent, note_id: note_id, note: note }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_note(::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note), grpc_options) do |response, operation|
+      client_stub.create_note(::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -756,36 +756,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_create_notes_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.batch_create_notes({ parent: parent, notes: notes }) do |response, operation|
+      client_stub.batch_create_notes({ parent: parent, notes: notes }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.batch_create_notes parent: parent, notes: notes do |response, operation|
+      client_stub.batch_create_notes parent: parent, notes: notes do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.batch_create_notes ::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes) do |response, operation|
+      client_stub.batch_create_notes ::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.batch_create_notes({ parent: parent, notes: notes }, grpc_options) do |response, operation|
+      client_stub.batch_create_notes({ parent: parent, notes: notes }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.batch_create_notes(::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes), grpc_options) do |response, operation|
+      client_stub.batch_create_notes(::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -818,36 +818,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_note_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_note({ name: name, note: note, update_mask: update_mask }) do |response, operation|
+      client_stub.update_note({ name: name, note: note, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_note name: name, note: note, update_mask: update_mask do |response, operation|
+      client_stub.update_note name: name, note: note, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_note ::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask) do |response, operation|
+      client_stub.update_note ::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_note({ name: name, note: note, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_note({ name: name, note: note, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_note(::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_note(::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -882,40 +882,40 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_note_occurrences_client_stub do
       # Create client
-      client = ::Grafeas::V1::Grafeas::Client.new do |config|
+      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_note_occurrences name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_note_occurrences name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_note_occurrences ::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_note_occurrences ::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_note_occurrences(::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_note_occurrences(::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
+++ b/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
@@ -82,36 +82,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_occurrence_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_occurrence({ name: name }) do |response, operation|
+      c.get_occurrence({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_occurrence name: name do |response, operation|
+      c.get_occurrence name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_occurrence ::Grafeas::V1::GetOccurrenceRequest.new(name: name) do |response, operation|
+      c.get_occurrence ::Grafeas::V1::GetOccurrenceRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_occurrence({ name: name }, grpc_options) do |response, operation|
+      c.get_occurrence({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_occurrence(::Grafeas::V1::GetOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_occurrence(::Grafeas::V1::GetOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -146,40 +146,40 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_occurrences_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_occurrences parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_occurrences parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_occurrences ::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_occurrences ::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_occurrences({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_occurrences(::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_occurrences(::Grafeas::V1::ListOccurrencesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -209,36 +209,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_occurrence_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_occurrence({ name: name }) do |response, operation|
+      c.delete_occurrence({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_occurrence name: name do |response, operation|
+      c.delete_occurrence name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_occurrence ::Grafeas::V1::DeleteOccurrenceRequest.new(name: name) do |response, operation|
+      c.delete_occurrence ::Grafeas::V1::DeleteOccurrenceRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_occurrence({ name: name }, grpc_options) do |response, operation|
+      c.delete_occurrence({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_occurrence(::Grafeas::V1::DeleteOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_occurrence(::Grafeas::V1::DeleteOccurrenceRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -269,36 +269,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_occurrence_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_occurrence({ parent: parent, occurrence: occurrence }) do |response, operation|
+      c.create_occurrence({ parent: parent, occurrence: occurrence }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_occurrence parent: parent, occurrence: occurrence do |response, operation|
+      c.create_occurrence parent: parent, occurrence: occurrence do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_occurrence ::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence) do |response, operation|
+      c.create_occurrence ::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_occurrence({ parent: parent, occurrence: occurrence }, grpc_options) do |response, operation|
+      c.create_occurrence({ parent: parent, occurrence: occurrence }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_occurrence(::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence), grpc_options) do |response, operation|
+      c.create_occurrence(::Grafeas::V1::CreateOccurrenceRequest.new(parent: parent, occurrence: occurrence), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_create_occurrences_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.batch_create_occurrences({ parent: parent, occurrences: occurrences }) do |response, operation|
+      c.batch_create_occurrences({ parent: parent, occurrences: occurrences }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.batch_create_occurrences parent: parent, occurrences: occurrences do |response, operation|
+      c.batch_create_occurrences parent: parent, occurrences: occurrences do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.batch_create_occurrences ::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences) do |response, operation|
+      c.batch_create_occurrences ::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.batch_create_occurrences({ parent: parent, occurrences: occurrences }, grpc_options) do |response, operation|
+      c.batch_create_occurrences({ parent: parent, occurrences: occurrences }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.batch_create_occurrences(::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences), grpc_options) do |response, operation|
+      c.batch_create_occurrences(::Grafeas::V1::BatchCreateOccurrencesRequest.new(parent: parent, occurrences: occurrences), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,36 +391,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_occurrence_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }) do |response, operation|
+      c.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_occurrence name: name, occurrence: occurrence, update_mask: update_mask do |response, operation|
+      c.update_occurrence name: name, occurrence: occurrence, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_occurrence ::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask) do |response, operation|
+      c.update_occurrence ::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_occurrence({ name: name, occurrence: occurrence, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_occurrence(::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_occurrence(::Grafeas::V1::UpdateOccurrenceRequest.new(name: name, occurrence: occurrence, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -449,36 +449,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_occurrence_note_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_occurrence_note({ name: name }) do |response, operation|
+      c.get_occurrence_note({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_occurrence_note name: name do |response, operation|
+      c.get_occurrence_note name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_occurrence_note ::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name) do |response, operation|
+      c.get_occurrence_note ::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_occurrence_note({ name: name }, grpc_options) do |response, operation|
+      c.get_occurrence_note({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_occurrence_note(::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_occurrence_note(::Grafeas::V1::GetOccurrenceNoteRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -507,36 +507,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_note_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_note({ name: name }) do |response, operation|
+      c.get_note({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_note name: name do |response, operation|
+      c.get_note name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_note ::Grafeas::V1::GetNoteRequest.new(name: name) do |response, operation|
+      c.get_note ::Grafeas::V1::GetNoteRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_note({ name: name }, grpc_options) do |response, operation|
+      c.get_note({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_note(::Grafeas::V1::GetNoteRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_note(::Grafeas::V1::GetNoteRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -571,40 +571,40 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_notes_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_notes parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_notes parent: parent, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_notes ::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_notes ::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_notes({ parent: parent, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_notes(::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_notes(::Grafeas::V1::ListNotesRequest.new(parent: parent, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -634,36 +634,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_note_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_note({ name: name }) do |response, operation|
+      c.delete_note({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_note name: name do |response, operation|
+      c.delete_note name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_note ::Grafeas::V1::DeleteNoteRequest.new(name: name) do |response, operation|
+      c.delete_note ::Grafeas::V1::DeleteNoteRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_note({ name: name }, grpc_options) do |response, operation|
+      c.delete_note({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_note(::Grafeas::V1::DeleteNoteRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_note(::Grafeas::V1::DeleteNoteRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -696,36 +696,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_note_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_note({ parent: parent, note_id: note_id, note: note }) do |response, operation|
+      c.create_note({ parent: parent, note_id: note_id, note: note }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_note parent: parent, note_id: note_id, note: note do |response, operation|
+      c.create_note parent: parent, note_id: note_id, note: note do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_note ::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note) do |response, operation|
+      c.create_note ::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_note({ parent: parent, note_id: note_id, note: note }, grpc_options) do |response, operation|
+      c.create_note({ parent: parent, note_id: note_id, note: note }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_note(::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note), grpc_options) do |response, operation|
+      c.create_note(::Grafeas::V1::CreateNoteRequest.new(parent: parent, note_id: note_id, note: note), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -756,36 +756,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_create_notes_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.batch_create_notes({ parent: parent, notes: notes }) do |response, operation|
+      c.batch_create_notes({ parent: parent, notes: notes }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.batch_create_notes parent: parent, notes: notes do |response, operation|
+      c.batch_create_notes parent: parent, notes: notes do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.batch_create_notes ::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes) do |response, operation|
+      c.batch_create_notes ::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.batch_create_notes({ parent: parent, notes: notes }, grpc_options) do |response, operation|
+      c.batch_create_notes({ parent: parent, notes: notes }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.batch_create_notes(::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes), grpc_options) do |response, operation|
+      c.batch_create_notes(::Grafeas::V1::BatchCreateNotesRequest.new(parent: parent, notes: notes), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -818,36 +818,36 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_note_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_note({ name: name, note: note, update_mask: update_mask }) do |response, operation|
+      c.update_note({ name: name, note: note, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_note name: name, note: note, update_mask: update_mask do |response, operation|
+      c.update_note name: name, note: note, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_note ::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask) do |response, operation|
+      c.update_note ::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_note({ name: name, note: note, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_note({ name: name, note: note, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_note(::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_note(::Grafeas::V1::UpdateNoteRequest.new(name: name, note: note, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -882,40 +882,40 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_note_occurrences_client_stub do
       # Create client
-      client_stub = ::Grafeas::V1::Grafeas::Client.new do |config|
+      c = ::Grafeas::V1::Grafeas::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_note_occurrences name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_note_occurrences name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_note_occurrences ::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_note_occurrences ::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_note_occurrences({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_note_occurrences(::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_note_occurrences(::Grafeas::V1::ListNoteOccurrencesRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_rest_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_rest_test.rb
@@ -98,32 +98,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_sentiment_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_sentiment_client_stub do
         # Create client
-        client = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
+        client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.analyze_sentiment document: document, encoding_type: encoding_type do |_result, response|
+        client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        client_stub.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.analyze_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        client_stub.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -153,32 +153,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_entities_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_entities_client_stub do
         # Create client
-        client = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.analyze_entities({ document: document, encoding_type: encoding_type }) do |_result, response|
+        client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.analyze_entities document: document, encoding_type: encoding_type do |_result, response|
+        client_stub.analyze_entities document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        client_stub.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.analyze_entities({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        client_stub.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -208,32 +208,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_entity_sentiment_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_entity_sentiment_client_stub do
         # Create client
-        client = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
+        client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.analyze_entity_sentiment document: document, encoding_type: encoding_type do |_result, response|
+        client_stub.analyze_entity_sentiment document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        client_stub.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        client_stub.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -263,32 +263,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_syntax_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_syntax_client_stub do
         # Create client
-        client = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |_result, response|
+        client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.analyze_syntax document: document, encoding_type: encoding_type do |_result, response|
+        client_stub.analyze_syntax document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        client_stub.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.analyze_syntax({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        client_stub.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -318,32 +318,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_classify_text_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, classify_text_client_stub do
         # Create client
-        client = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.classify_text({ document: document, classification_model_options: classification_model_options }) do |_result, response|
+        client_stub.classify_text({ document: document, classification_model_options: classification_model_options }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.classify_text document: document, classification_model_options: classification_model_options do |_result, response|
+        client_stub.classify_text document: document, classification_model_options: classification_model_options do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |_result, response|
+        client_stub.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.classify_text({ document: document, classification_model_options: classification_model_options }, call_options) do |_result, response|
+        client_stub.classify_text({ document: document, classification_model_options: classification_model_options }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), call_options) do |_result, response|
+        client_stub.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -372,32 +372,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_moderate_text_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, moderate_text_client_stub do
         # Create client
-        client = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.moderate_text({ document: document }) do |_result, response|
+        client_stub.moderate_text({ document: document }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.moderate_text document: document do |_result, response|
+        client_stub.moderate_text document: document do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |_result, response|
+        client_stub.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.moderate_text({ document: document }, call_options) do |_result, response|
+        client_stub.moderate_text({ document: document }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), call_options) do |_result, response|
+        client_stub.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -428,32 +428,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_annotate_text_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, annotate_text_client_stub do
         # Create client
-        client = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |_result, response|
+        client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.annotate_text document: document, features: features, encoding_type: encoding_type do |_result, response|
+        client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |_result, response|
+        client_stub.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.annotate_text({ document: document, features: features, encoding_type: encoding_type }, call_options) do |_result, response|
+        client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), call_options) do |_result, response|
+        client_stub.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_rest_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_rest_test.rb
@@ -98,32 +98,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_sentiment_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_sentiment_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        c = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
+        c.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |_result, response|
+        c.analyze_sentiment document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        c.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        c.analyze_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        c.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -153,32 +153,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_entities_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_entities_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        c = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |_result, response|
+        c.analyze_entities({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.analyze_entities document: document, encoding_type: encoding_type do |_result, response|
+        c.analyze_entities document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        c.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        c.analyze_entities({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        c.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -208,32 +208,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_entity_sentiment_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_entity_sentiment_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        c = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
+        c.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.analyze_entity_sentiment document: document, encoding_type: encoding_type do |_result, response|
+        c.analyze_entity_sentiment document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        c.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        c.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        c.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -263,32 +263,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_analyze_syntax_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, analyze_syntax_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        c = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |_result, response|
+        c.analyze_syntax({ document: document, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.analyze_syntax document: document, encoding_type: encoding_type do |_result, response|
+        c.analyze_syntax document: document, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
+        c.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
+        c.analyze_syntax({ document: document, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
+        c.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -318,32 +318,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_classify_text_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, classify_text_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        c = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.classify_text({ document: document, classification_model_options: classification_model_options }) do |_result, response|
+        c.classify_text({ document: document, classification_model_options: classification_model_options }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.classify_text document: document, classification_model_options: classification_model_options do |_result, response|
+        c.classify_text document: document, classification_model_options: classification_model_options do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |_result, response|
+        c.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.classify_text({ document: document, classification_model_options: classification_model_options }, call_options) do |_result, response|
+        c.classify_text({ document: document, classification_model_options: classification_model_options }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), call_options) do |_result, response|
+        c.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -372,32 +372,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_moderate_text_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, moderate_text_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        c = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.moderate_text({ document: document }) do |_result, response|
+        c.moderate_text({ document: document }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.moderate_text document: document do |_result, response|
+        c.moderate_text document: document do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |_result, response|
+        c.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.moderate_text({ document: document }, call_options) do |_result, response|
+        c.moderate_text({ document: document }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), call_options) do |_result, response|
+        c.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -428,32 +428,32 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     ::Google::Cloud::Language::V1::LanguageService::Rest::ServiceStub.stub :transcode_annotate_text_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, annotate_text_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
+        c = ::Google::Cloud::Language::V1::LanguageService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |_result, response|
+        c.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |_result, response|
+        c.annotate_text document: document, features: features, encoding_type: encoding_type do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |_result, response|
+        c.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, call_options) do |_result, response|
+        c.annotate_text({ document: document, features: features, encoding_type: encoding_type }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), call_options) do |_result, response|
+        c.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_sentiment_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_entities_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -204,36 +204,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_entity_sentiment_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_syntax_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -324,36 +324,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, classify_text_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
+      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
+      client_stub.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
+      client_stub.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
+      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
+      client_stub.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -382,36 +382,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, moderate_text_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.moderate_text({ document: document }) do |response, operation|
+      client_stub.moderate_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.moderate_text document: document do |response, operation|
+      client_stub.moderate_text document: document do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |response, operation|
+      client_stub.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.moderate_text({ document: document }, grpc_options) do |response, operation|
+      client_stub.moderate_text({ document: document }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
+      client_stub.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -444,36 +444,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, annotate_text_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
+      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
+      client_stub.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_sentiment_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_sentiment ::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_sentiment(::Google::Cloud::Language::V1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_entities_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_entities ::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_entities(::Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -204,36 +204,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_entity_sentiment_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_entity_sentiment ::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_entity_sentiment(::Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, analyze_syntax_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_syntax ::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_syntax(::Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -324,36 +324,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, classify_text_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
+      c.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
+      c.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
+      c.classify_text ::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
+      c.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
+      c.classify_text(::Google::Cloud::Language::V1::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -382,36 +382,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, moderate_text_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.moderate_text({ document: document }) do |response, operation|
+      c.moderate_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.moderate_text document: document do |response, operation|
+      c.moderate_text document: document do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |response, operation|
+      c.moderate_text ::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.moderate_text({ document: document }, grpc_options) do |response, operation|
+      c.moderate_text({ document: document }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
+      c.moderate_text(::Google::Cloud::Language::V1::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -444,36 +444,36 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, annotate_text_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
+      c.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      c.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
+      c.annotate_text ::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.annotate_text(::Google::Cloud::Language::V1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_sentiment_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_sentiment ::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_sentiment ::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_sentiment(::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_sentiment(::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_entities_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_entities ::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_entities ::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_entities(::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_entities(::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -204,36 +204,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_syntax_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_syntax ::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_syntax ::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_syntax(::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_syntax(::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -266,36 +266,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, annotate_text_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
+      c.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      c.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.annotate_text ::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
+      c.annotate_text ::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.annotate_text(::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.annotate_text(::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_sentiment_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_sentiment ::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_sentiment ::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_sentiment(::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_sentiment(::Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_entities_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_entities ::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_entities ::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_entities(::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_entities(::Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -204,36 +204,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_syntax_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_syntax ::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_syntax ::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_syntax(::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_syntax(::Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -266,36 +266,36 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, annotate_text_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
+      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.annotate_text ::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
+      client_stub.annotate_text ::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.annotate_text(::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.annotate_text(::Google::Cloud::Language::V1beta1::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_sentiment_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_entities_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_entities ::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_entities ::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_entities(::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_entities(::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -204,36 +204,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_entity_sentiment_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_entity_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_entity_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_entity_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_entity_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_syntax_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
+      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client_stub.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.analyze_syntax ::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      client_stub.analyze_syntax ::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.analyze_syntax(::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.analyze_syntax(::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -324,36 +324,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, classify_text_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
+      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
+      client_stub.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.classify_text ::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
+      client_stub.classify_text ::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
+      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.classify_text(::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
+      client_stub.classify_text(::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -382,36 +382,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, moderate_text_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.moderate_text({ document: document }) do |response, operation|
+      client_stub.moderate_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.moderate_text document: document do |response, operation|
+      client_stub.moderate_text document: document do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.moderate_text ::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document) do |response, operation|
+      client_stub.moderate_text ::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.moderate_text({ document: document }, grpc_options) do |response, operation|
+      client_stub.moderate_text({ document: document }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.moderate_text(::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
+      client_stub.moderate_text(::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -444,36 +444,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, annotate_text_client_stub do
       # Create client
-      client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
+      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.annotate_text ::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
+      client_stub.annotate_text ::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.annotate_text(::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
+      client_stub.annotate_text(::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_sentiment_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_entities_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_entities ::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_entities ::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_entities({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_entities(::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_entities(::Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -204,36 +204,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_entity_sentiment_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_entity_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_entity_sentiment ::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_entity_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_entity_sentiment(::Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, analyze_syntax_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
+      c.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      c.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.analyze_syntax ::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
+      c.analyze_syntax ::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.analyze_syntax({ document: document, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.analyze_syntax(::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.analyze_syntax(::Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new(document: document, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -324,36 +324,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, classify_text_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
+      c.classify_text({ document: document, classification_model_options: classification_model_options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
+      c.classify_text document: document, classification_model_options: classification_model_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.classify_text ::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
+      c.classify_text ::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
+      c.classify_text({ document: document, classification_model_options: classification_model_options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.classify_text(::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
+      c.classify_text(::Google::Cloud::Language::V1beta2::ClassifyTextRequest.new(document: document, classification_model_options: classification_model_options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -382,36 +382,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, moderate_text_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.moderate_text({ document: document }) do |response, operation|
+      c.moderate_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.moderate_text document: document do |response, operation|
+      c.moderate_text document: document do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.moderate_text ::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document) do |response, operation|
+      c.moderate_text ::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.moderate_text({ document: document }, grpc_options) do |response, operation|
+      c.moderate_text({ document: document }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.moderate_text(::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
+      c.moderate_text(::Google::Cloud::Language::V1beta2::ModerateTextRequest.new(document: document), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -444,36 +444,36 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
 
     Gapic::ServiceStub.stub :new, annotate_text_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+      c = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
+      c.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      c.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.annotate_text ::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
+      c.annotate_text ::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
+      c.annotate_text({ document: document, features: features, encoding_type: encoding_type }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.annotate_text(::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
+      c.annotate_text(::Google::Cloud::Language::V1beta2::AnnotateTextRequest.new(document: document, features: features, encoding_type: encoding_type), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/location/test/google/cloud/location/locations_rest_test.rb
+++ b/shared/output/cloud/location/test/google/cloud/location/locations_rest_test.rb
@@ -100,32 +100,32 @@ class ::Google::Cloud::Location::Locations::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Location::Locations::Rest::ServiceStub.stub :transcode_list_locations_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_locations_client_stub do
         # Create client
-        client = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -154,32 +154,32 @@ class ::Google::Cloud::Location::Locations::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Location::Locations::Rest::ServiceStub.stub :transcode_get_location_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_location_client_stub do
         # Create client
-        client = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_location({ name: name }) do |_result, response|
+        client_stub.get_location({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_location name: name do |_result, response|
+        client_stub.get_location name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |_result, response|
+        client_stub.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_location({ name: name }, call_options) do |_result, response|
+        client_stub.get_location({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/location/test/google/cloud/location/locations_rest_test.rb
+++ b/shared/output/cloud/location/test/google/cloud/location/locations_rest_test.rb
@@ -100,32 +100,32 @@ class ::Google::Cloud::Location::Locations::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Location::Locations::Rest::ServiceStub.stub :transcode_list_locations_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_locations_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -154,32 +154,32 @@ class ::Google::Cloud::Location::Locations::Rest::ClientTest < Minitest::Test
     ::Google::Cloud::Location::Locations::Rest::ServiceStub.stub :transcode_get_location_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_location_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
+        c = ::Google::Cloud::Location::Locations::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_location({ name: name }) do |_result, response|
+        c.get_location({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_location name: name do |_result, response|
+        c.get_location name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |_result, response|
+        c.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_location({ name: name }, call_options) do |_result, response|
+        c.get_location({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), call_options) do |_result, response|
+        c.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
+++ b/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
@@ -88,40 +88,40 @@ class ::Google::Cloud::Location::Locations::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_locations_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Location::Locations::Client.new do |config|
+      c = ::Google::Cloud::Location::Locations::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -151,36 +151,36 @@ class ::Google::Cloud::Location::Locations::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_location_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Location::Locations::Client.new do |config|
+      c = ::Google::Cloud::Location::Locations::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_location({ name: name }) do |response, operation|
+      c.get_location({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_location name: name do |response, operation|
+      c.get_location name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |response, operation|
+      c.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_location({ name: name }, grpc_options) do |response, operation|
+      c.get_location({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
+++ b/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
@@ -88,40 +88,40 @@ class ::Google::Cloud::Location::Locations::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_locations_client_stub do
       # Create client
-      client = ::Google::Cloud::Location::Locations::Client.new do |config|
+      client_stub = ::Google::Cloud::Location::Locations::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_locations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_locations ::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_locations({ name: name, filter: filter, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_locations(::Google::Cloud::Location::ListLocationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -151,36 +151,36 @@ class ::Google::Cloud::Location::Locations::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_location_client_stub do
       # Create client
-      client = ::Google::Cloud::Location::Locations::Client.new do |config|
+      client_stub = ::Google::Cloud::Location::Locations::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_location({ name: name }) do |response, operation|
+      client_stub.get_location({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_location name: name do |response, operation|
+      client_stub.get_location name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |response, operation|
+      client_stub.get_location ::Google::Cloud::Location::GetLocationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_location({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_location({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_location(::Google::Cloud::Location::GetLocationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -86,40 +86,40 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, list_secrets_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_secrets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_secrets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_secrets ::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_secrets ::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_secrets(::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_secrets(::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -153,36 +153,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, create_secret_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_secret({ parent: parent, secret_id: secret_id, secret: secret }) do |response, operation|
+      c.create_secret({ parent: parent, secret_id: secret_id, secret: secret }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_secret parent: parent, secret_id: secret_id, secret: secret do |response, operation|
+      c.create_secret parent: parent, secret_id: secret_id, secret: secret do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_secret ::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret) do |response, operation|
+      c.create_secret ::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_secret({ parent: parent, secret_id: secret_id, secret: secret }, grpc_options) do |response, operation|
+      c.create_secret({ parent: parent, secret_id: secret_id, secret: secret }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_secret(::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret), grpc_options) do |response, operation|
+      c.create_secret(::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -213,36 +213,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, add_secret_version_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.add_secret_version({ parent: parent, payload: payload }) do |response, operation|
+      c.add_secret_version({ parent: parent, payload: payload }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.add_secret_version parent: parent, payload: payload do |response, operation|
+      c.add_secret_version parent: parent, payload: payload do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.add_secret_version ::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload) do |response, operation|
+      c.add_secret_version ::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.add_secret_version({ parent: parent, payload: payload }, grpc_options) do |response, operation|
+      c.add_secret_version({ parent: parent, payload: payload }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.add_secret_version(::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload), grpc_options) do |response, operation|
+      c.add_secret_version(::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -271,36 +271,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, get_secret_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_secret({ name: name }) do |response, operation|
+      c.get_secret({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_secret name: name do |response, operation|
+      c.get_secret name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_secret ::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name) do |response, operation|
+      c.get_secret ::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_secret({ name: name }, grpc_options) do |response, operation|
+      c.get_secret({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_secret(::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_secret(::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -331,36 +331,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, update_secret_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_secret({ secret: secret, update_mask: update_mask }) do |response, operation|
+      c.update_secret({ secret: secret, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_secret secret: secret, update_mask: update_mask do |response, operation|
+      c.update_secret secret: secret, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_secret ::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask) do |response, operation|
+      c.update_secret ::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_secret({ secret: secret, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_secret({ secret: secret, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_secret(::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_secret(::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -389,36 +389,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, delete_secret_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_secret({ name: name }) do |response, operation|
+      c.delete_secret({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_secret name: name do |response, operation|
+      c.delete_secret name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_secret ::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name) do |response, operation|
+      c.delete_secret ::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_secret({ name: name }, grpc_options) do |response, operation|
+      c.delete_secret({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_secret(::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_secret(::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -451,40 +451,40 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, list_secret_versions_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_secret_versions parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_secret_versions parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_secret_versions ::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_secret_versions ::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_secret_versions(::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_secret_versions(::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -514,36 +514,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, get_secret_version_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_secret_version({ name: name }) do |response, operation|
+      c.get_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_secret_version name: name do |response, operation|
+      c.get_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_secret_version ::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name) do |response, operation|
+      c.get_secret_version ::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_secret_version({ name: name }, grpc_options) do |response, operation|
+      c.get_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_secret_version(::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_secret_version(::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -572,36 +572,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, access_secret_version_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.access_secret_version({ name: name }) do |response, operation|
+      c.access_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.access_secret_version name: name do |response, operation|
+      c.access_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.access_secret_version ::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name) do |response, operation|
+      c.access_secret_version ::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.access_secret_version({ name: name }, grpc_options) do |response, operation|
+      c.access_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.access_secret_version(::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      c.access_secret_version(::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -630,36 +630,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, disable_secret_version_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.disable_secret_version({ name: name }) do |response, operation|
+      c.disable_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.disable_secret_version name: name do |response, operation|
+      c.disable_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.disable_secret_version ::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name) do |response, operation|
+      c.disable_secret_version ::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.disable_secret_version({ name: name }, grpc_options) do |response, operation|
+      c.disable_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.disable_secret_version(::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      c.disable_secret_version(::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -688,36 +688,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, enable_secret_version_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.enable_secret_version({ name: name }) do |response, operation|
+      c.enable_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.enable_secret_version name: name do |response, operation|
+      c.enable_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.enable_secret_version ::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name) do |response, operation|
+      c.enable_secret_version ::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.enable_secret_version({ name: name }, grpc_options) do |response, operation|
+      c.enable_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.enable_secret_version(::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      c.enable_secret_version(::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -746,36 +746,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, destroy_secret_version_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.destroy_secret_version({ name: name }) do |response, operation|
+      c.destroy_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.destroy_secret_version name: name do |response, operation|
+      c.destroy_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.destroy_secret_version ::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name) do |response, operation|
+      c.destroy_secret_version ::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.destroy_secret_version({ name: name }, grpc_options) do |response, operation|
+      c.destroy_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.destroy_secret_version(::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      c.destroy_secret_version(::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -808,36 +808,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, set_iam_policy_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
+      c.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
+      c.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
+      c.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
+      c.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -868,36 +868,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, get_iam_policy_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_iam_policy({ resource: resource, options: options }) do |response, operation|
+      c.get_iam_policy({ resource: resource, options: options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_iam_policy resource: resource, options: options do |response, operation|
+      c.get_iam_policy resource: resource, options: options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
+      c.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
+      c.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
+      c.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -928,36 +928,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, test_iam_permissions_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      c = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
+      c.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
+      c.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
+      c.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
+      c.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
+      c.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -86,40 +86,40 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, list_secrets_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_secrets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_secrets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_secrets ::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_secrets ::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_secrets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_secrets(::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_secrets(::Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -153,36 +153,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, create_secret_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_secret({ parent: parent, secret_id: secret_id, secret: secret }) do |response, operation|
+      client_stub.create_secret({ parent: parent, secret_id: secret_id, secret: secret }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_secret parent: parent, secret_id: secret_id, secret: secret do |response, operation|
+      client_stub.create_secret parent: parent, secret_id: secret_id, secret: secret do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_secret ::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret) do |response, operation|
+      client_stub.create_secret ::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_secret({ parent: parent, secret_id: secret_id, secret: secret }, grpc_options) do |response, operation|
+      client_stub.create_secret({ parent: parent, secret_id: secret_id, secret: secret }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_secret(::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret), grpc_options) do |response, operation|
+      client_stub.create_secret(::Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new(parent: parent, secret_id: secret_id, secret: secret), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -213,36 +213,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, add_secret_version_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.add_secret_version({ parent: parent, payload: payload }) do |response, operation|
+      client_stub.add_secret_version({ parent: parent, payload: payload }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.add_secret_version parent: parent, payload: payload do |response, operation|
+      client_stub.add_secret_version parent: parent, payload: payload do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.add_secret_version ::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload) do |response, operation|
+      client_stub.add_secret_version ::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.add_secret_version({ parent: parent, payload: payload }, grpc_options) do |response, operation|
+      client_stub.add_secret_version({ parent: parent, payload: payload }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.add_secret_version(::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload), grpc_options) do |response, operation|
+      client_stub.add_secret_version(::Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new(parent: parent, payload: payload), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -271,36 +271,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, get_secret_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_secret({ name: name }) do |response, operation|
+      client_stub.get_secret({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_secret name: name do |response, operation|
+      client_stub.get_secret name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_secret ::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name) do |response, operation|
+      client_stub.get_secret ::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_secret({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_secret({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_secret(::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_secret(::Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -331,36 +331,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, update_secret_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_secret({ secret: secret, update_mask: update_mask }) do |response, operation|
+      client_stub.update_secret({ secret: secret, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_secret secret: secret, update_mask: update_mask do |response, operation|
+      client_stub.update_secret secret: secret, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_secret ::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask) do |response, operation|
+      client_stub.update_secret ::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_secret({ secret: secret, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_secret({ secret: secret, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_secret(::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_secret(::Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new(secret: secret, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -389,36 +389,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, delete_secret_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_secret({ name: name }) do |response, operation|
+      client_stub.delete_secret({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_secret name: name do |response, operation|
+      client_stub.delete_secret name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_secret ::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name) do |response, operation|
+      client_stub.delete_secret ::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_secret({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_secret({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_secret(::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_secret(::Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -451,40 +451,40 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, list_secret_versions_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_secret_versions parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_secret_versions parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_secret_versions ::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_secret_versions ::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_secret_versions({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_secret_versions(::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_secret_versions(::Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -514,36 +514,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, get_secret_version_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_secret_version({ name: name }) do |response, operation|
+      client_stub.get_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_secret_version name: name do |response, operation|
+      client_stub.get_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_secret_version ::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name) do |response, operation|
+      client_stub.get_secret_version ::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_secret_version({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_secret_version(::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_secret_version(::Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -572,36 +572,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, access_secret_version_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.access_secret_version({ name: name }) do |response, operation|
+      client_stub.access_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.access_secret_version name: name do |response, operation|
+      client_stub.access_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.access_secret_version ::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name) do |response, operation|
+      client_stub.access_secret_version ::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.access_secret_version({ name: name }, grpc_options) do |response, operation|
+      client_stub.access_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.access_secret_version(::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.access_secret_version(::Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -630,36 +630,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, disable_secret_version_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.disable_secret_version({ name: name }) do |response, operation|
+      client_stub.disable_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.disable_secret_version name: name do |response, operation|
+      client_stub.disable_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.disable_secret_version ::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name) do |response, operation|
+      client_stub.disable_secret_version ::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.disable_secret_version({ name: name }, grpc_options) do |response, operation|
+      client_stub.disable_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.disable_secret_version(::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.disable_secret_version(::Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -688,36 +688,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, enable_secret_version_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.enable_secret_version({ name: name }) do |response, operation|
+      client_stub.enable_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.enable_secret_version name: name do |response, operation|
+      client_stub.enable_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.enable_secret_version ::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name) do |response, operation|
+      client_stub.enable_secret_version ::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.enable_secret_version({ name: name }, grpc_options) do |response, operation|
+      client_stub.enable_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.enable_secret_version(::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.enable_secret_version(::Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -746,36 +746,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, destroy_secret_version_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.destroy_secret_version({ name: name }) do |response, operation|
+      client_stub.destroy_secret_version({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.destroy_secret_version name: name do |response, operation|
+      client_stub.destroy_secret_version name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.destroy_secret_version ::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name) do |response, operation|
+      client_stub.destroy_secret_version ::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.destroy_secret_version({ name: name }, grpc_options) do |response, operation|
+      client_stub.destroy_secret_version({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.destroy_secret_version(::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.destroy_secret_version(::Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -808,36 +808,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, set_iam_policy_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
+      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
+      client_stub.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
+      client_stub.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -868,36 +868,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, get_iam_policy_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_iam_policy({ resource: resource, options: options }) do |response, operation|
+      client_stub.get_iam_policy({ resource: resource, options: options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_iam_policy resource: resource, options: options do |response, operation|
+      client_stub.get_iam_policy resource: resource, options: options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
+      client_stub.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
+      client_stub.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
+      client_stub.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -928,36 +928,36 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
 
     Gapic::ServiceStub.stub :new, test_iam_permissions_client_stub do
       # Create client
-      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+      client_stub = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
+      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
+      client_stub.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
+      client_stub.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
+      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
+      client_stub.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_phrase_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }) do |response, operation|
+      c.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_phrase_set parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set do |response, operation|
+      c.create_phrase_set parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_phrase_set ::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set) do |response, operation|
+      c.create_phrase_set ::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }, grpc_options) do |response, operation|
+      c.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_phrase_set(::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set), grpc_options) do |response, operation|
+      c.create_phrase_set(::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_phrase_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_phrase_set({ name: name }) do |response, operation|
+      c.get_phrase_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_phrase_set name: name do |response, operation|
+      c.get_phrase_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_phrase_set ::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name) do |response, operation|
+      c.get_phrase_set ::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_phrase_set({ name: name }, grpc_options) do |response, operation|
+      c.get_phrase_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_phrase_set(::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_phrase_set(::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -206,40 +206,40 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_phrase_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_phrase_set parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_phrase_set parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_phrase_set ::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_phrase_set ::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_phrase_set(::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_phrase_set(::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -271,36 +271,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_phrase_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }) do |response, operation|
+      c.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_phrase_set phrase_set: phrase_set, update_mask: update_mask do |response, operation|
+      c.update_phrase_set phrase_set: phrase_set, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_phrase_set ::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask) do |response, operation|
+      c.update_phrase_set ::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_phrase_set(::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_phrase_set(::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_phrase_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_phrase_set({ name: name }) do |response, operation|
+      c.delete_phrase_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_phrase_set name: name do |response, operation|
+      c.delete_phrase_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_phrase_set ::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name) do |response, operation|
+      c.delete_phrase_set ::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_phrase_set({ name: name }, grpc_options) do |response, operation|
+      c.delete_phrase_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_phrase_set(::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_phrase_set(::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,36 +391,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_custom_class_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }) do |response, operation|
+      c.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_custom_class parent: parent, custom_class_id: custom_class_id, custom_class: custom_class do |response, operation|
+      c.create_custom_class parent: parent, custom_class_id: custom_class_id, custom_class: custom_class do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_custom_class ::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class) do |response, operation|
+      c.create_custom_class ::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }, grpc_options) do |response, operation|
+      c.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_custom_class(::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class), grpc_options) do |response, operation|
+      c.create_custom_class(::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -449,36 +449,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_custom_class_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_custom_class({ name: name }) do |response, operation|
+      c.get_custom_class({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_custom_class name: name do |response, operation|
+      c.get_custom_class name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_custom_class ::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name) do |response, operation|
+      c.get_custom_class ::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_custom_class({ name: name }, grpc_options) do |response, operation|
+      c.get_custom_class({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_custom_class(::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_custom_class(::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -511,40 +511,40 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_custom_classes_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_custom_classes parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_custom_classes parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_custom_classes ::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_custom_classes ::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_custom_classes(::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_custom_classes(::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -576,36 +576,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_custom_class_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_custom_class({ custom_class: custom_class, update_mask: update_mask }) do |response, operation|
+      c.update_custom_class({ custom_class: custom_class, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_custom_class custom_class: custom_class, update_mask: update_mask do |response, operation|
+      c.update_custom_class custom_class: custom_class, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_custom_class ::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask) do |response, operation|
+      c.update_custom_class ::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_custom_class({ custom_class: custom_class, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_custom_class({ custom_class: custom_class, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_custom_class(::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_custom_class(::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -634,36 +634,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_custom_class_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_custom_class({ name: name }) do |response, operation|
+      c.delete_custom_class({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_custom_class name: name do |response, operation|
+      c.delete_custom_class name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_custom_class ::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name) do |response, operation|
+      c.delete_custom_class ::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_custom_class({ name: name }, grpc_options) do |response, operation|
+      c.delete_custom_class({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_custom_class(::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_custom_class(::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_phrase_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }) do |response, operation|
+      client_stub.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_phrase_set parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set do |response, operation|
+      client_stub.create_phrase_set parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_phrase_set ::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set) do |response, operation|
+      client_stub.create_phrase_set ::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }, grpc_options) do |response, operation|
+      client_stub.create_phrase_set({ parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_phrase_set(::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set), grpc_options) do |response, operation|
+      client_stub.create_phrase_set(::Google::Cloud::Speech::V1::CreatePhraseSetRequest.new(parent: parent, phrase_set_id: phrase_set_id, phrase_set: phrase_set), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -144,36 +144,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_phrase_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_phrase_set({ name: name }) do |response, operation|
+      client_stub.get_phrase_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_phrase_set name: name do |response, operation|
+      client_stub.get_phrase_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_phrase_set ::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name) do |response, operation|
+      client_stub.get_phrase_set ::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_phrase_set({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_phrase_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_phrase_set(::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_phrase_set(::Google::Cloud::Speech::V1::GetPhraseSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -206,40 +206,40 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_phrase_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_phrase_set parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_phrase_set parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_phrase_set ::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_phrase_set ::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_phrase_set({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_phrase_set(::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_phrase_set(::Google::Cloud::Speech::V1::ListPhraseSetRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -271,36 +271,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_phrase_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }) do |response, operation|
+      client_stub.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_phrase_set phrase_set: phrase_set, update_mask: update_mask do |response, operation|
+      client_stub.update_phrase_set phrase_set: phrase_set, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_phrase_set ::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask) do |response, operation|
+      client_stub.update_phrase_set ::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_phrase_set({ phrase_set: phrase_set, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_phrase_set(::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_phrase_set(::Google::Cloud::Speech::V1::UpdatePhraseSetRequest.new(phrase_set: phrase_set, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_phrase_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_phrase_set({ name: name }) do |response, operation|
+      client_stub.delete_phrase_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_phrase_set name: name do |response, operation|
+      client_stub.delete_phrase_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_phrase_set ::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name) do |response, operation|
+      client_stub.delete_phrase_set ::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_phrase_set({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_phrase_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_phrase_set(::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_phrase_set(::Google::Cloud::Speech::V1::DeletePhraseSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,36 +391,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_custom_class_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }) do |response, operation|
+      client_stub.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_custom_class parent: parent, custom_class_id: custom_class_id, custom_class: custom_class do |response, operation|
+      client_stub.create_custom_class parent: parent, custom_class_id: custom_class_id, custom_class: custom_class do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_custom_class ::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class) do |response, operation|
+      client_stub.create_custom_class ::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }, grpc_options) do |response, operation|
+      client_stub.create_custom_class({ parent: parent, custom_class_id: custom_class_id, custom_class: custom_class }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_custom_class(::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class), grpc_options) do |response, operation|
+      client_stub.create_custom_class(::Google::Cloud::Speech::V1::CreateCustomClassRequest.new(parent: parent, custom_class_id: custom_class_id, custom_class: custom_class), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -449,36 +449,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_custom_class_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_custom_class({ name: name }) do |response, operation|
+      client_stub.get_custom_class({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_custom_class name: name do |response, operation|
+      client_stub.get_custom_class name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_custom_class ::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name) do |response, operation|
+      client_stub.get_custom_class ::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_custom_class({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_custom_class({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_custom_class(::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_custom_class(::Google::Cloud::Speech::V1::GetCustomClassRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -511,40 +511,40 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_custom_classes_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_custom_classes parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_custom_classes parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_custom_classes ::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_custom_classes ::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_custom_classes({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_custom_classes(::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_custom_classes(::Google::Cloud::Speech::V1::ListCustomClassesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -576,36 +576,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_custom_class_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_custom_class({ custom_class: custom_class, update_mask: update_mask }) do |response, operation|
+      client_stub.update_custom_class({ custom_class: custom_class, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_custom_class custom_class: custom_class, update_mask: update_mask do |response, operation|
+      client_stub.update_custom_class custom_class: custom_class, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_custom_class ::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask) do |response, operation|
+      client_stub.update_custom_class ::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_custom_class({ custom_class: custom_class, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_custom_class({ custom_class: custom_class, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_custom_class(::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_custom_class(::Google::Cloud::Speech::V1::UpdateCustomClassRequest.new(custom_class: custom_class, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -634,36 +634,36 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_custom_class_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Adaptation::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_custom_class({ name: name }) do |response, operation|
+      client_stub.delete_custom_class({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_custom_class name: name do |response, operation|
+      client_stub.delete_custom_class name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_custom_class ::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name) do |response, operation|
+      client_stub.delete_custom_class ::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_custom_class({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_custom_class({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_custom_class(::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_custom_class(::Google::Cloud::Speech::V1::DeleteCustomClassRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, recognize_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.recognize({ config: config, audio: audio }) do |response, operation|
+      c.recognize({ config: config, audio: audio }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.recognize config: config, audio: audio do |response, operation|
+      c.recognize config: config, audio: audio do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.recognize ::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio) do |response, operation|
+      c.recognize ::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.recognize({ config: config, audio: audio }, grpc_options) do |response, operation|
+      c.recognize({ config: config, audio: audio }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.recognize(::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio), grpc_options) do |response, operation|
+      c.recognize(::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -146,40 +146,40 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, long_running_recognize_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.long_running_recognize({ config: config, audio: audio, output_config: output_config }) do |response, operation|
+      c.long_running_recognize({ config: config, audio: audio, output_config: output_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.long_running_recognize config: config, audio: audio, output_config: output_config do |response, operation|
+      c.long_running_recognize config: config, audio: audio, output_config: output_config do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.long_running_recognize ::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config) do |response, operation|
+      c.long_running_recognize ::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.long_running_recognize({ config: config, audio: audio, output_config: output_config }, grpc_options) do |response, operation|
+      c.long_running_recognize({ config: config, audio: audio, output_config: output_config }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.long_running_recognize(::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config), grpc_options) do |response, operation|
+      c.long_running_recognize(::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -209,7 +209,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, streaming_recognize_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
+      c = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -217,7 +217,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.streaming_recognize enum_input do |response, operation|
+      c.streaming_recognize enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r
@@ -229,7 +229,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       stream_input = Gapic::StreamInput.new
-      client_stub.streaming_recognize stream_input do |response, operation|
+      c.streaming_recognize stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r
@@ -244,7 +244,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.streaming_recognize enum_input, grpc_options do |response, operation|
+      c.streaming_recognize enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r
@@ -256,7 +256,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       stream_input = Gapic::StreamInput.new
-      client_stub.streaming_recognize stream_input, grpc_options do |response, operation|
+      c.streaming_recognize stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -84,36 +84,36 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, recognize_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.recognize({ config: config, audio: audio }) do |response, operation|
+      client_stub.recognize({ config: config, audio: audio }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.recognize config: config, audio: audio do |response, operation|
+      client_stub.recognize config: config, audio: audio do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.recognize ::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio) do |response, operation|
+      client_stub.recognize ::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.recognize({ config: config, audio: audio }, grpc_options) do |response, operation|
+      client_stub.recognize({ config: config, audio: audio }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.recognize(::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio), grpc_options) do |response, operation|
+      client_stub.recognize(::Google::Cloud::Speech::V1::RecognizeRequest.new(config: config, audio: audio), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -146,40 +146,40 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, long_running_recognize_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.long_running_recognize({ config: config, audio: audio, output_config: output_config }) do |response, operation|
+      client_stub.long_running_recognize({ config: config, audio: audio, output_config: output_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.long_running_recognize config: config, audio: audio, output_config: output_config do |response, operation|
+      client_stub.long_running_recognize config: config, audio: audio, output_config: output_config do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.long_running_recognize ::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config) do |response, operation|
+      client_stub.long_running_recognize ::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.long_running_recognize({ config: config, audio: audio, output_config: output_config }, grpc_options) do |response, operation|
+      client_stub.long_running_recognize({ config: config, audio: audio, output_config: output_config }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.long_running_recognize(::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config), grpc_options) do |response, operation|
+      client_stub.long_running_recognize(::Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new(config: config, audio: audio, output_config: output_config), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -209,7 +209,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, streaming_recognize_client_stub do
       # Create client
-      client = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
+      client_stub = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -217,7 +217,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       enum_input = [request_hash, request_proto].to_enum
-      client.streaming_recognize enum_input do |response, operation|
+      client_stub.streaming_recognize enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r
@@ -229,7 +229,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       stream_input = Gapic::StreamInput.new
-      client.streaming_recognize stream_input do |response, operation|
+      client_stub.streaming_recognize stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r
@@ -244,7 +244,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       enum_input = [request_hash, request_proto].to_enum
-      client.streaming_recognize enum_input, grpc_options do |response, operation|
+      client_stub.streaming_recognize enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r
@@ -256,7 +256,7 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       request_hash = { streaming_config: streaming_config }
       request_proto = ::Google::Cloud::Speech::V1::StreamingRecognizeRequest.new streaming_config: streaming_config
       stream_input = Gapic::StreamInput.new
-      client.streaming_recognize stream_input, grpc_options do |response, operation|
+      client_stub.streaming_recognize stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Cloud::Speech::V1::StreamingRecognizeResponse, r

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_batch_annotate_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, batch_annotate_images_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.batch_annotate_images requests: requests, parent: parent, labels: labels do |_result, response|
+        c.batch_annotate_images requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        c.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        c.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_batch_annotate_files_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, batch_annotate_files_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
+        c.batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        c.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        c.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -212,32 +212,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_async_batch_annotate_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, async_batch_annotate_images_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |_result, response|
+        c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |_result, response|
+        c.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |_result, response|
+        c.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), call_options) do |_result, response|
+        c.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_async_batch_annotate_files_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, async_batch_annotate_files_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
+        c.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        c.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        c.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_batch_annotate_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, batch_annotate_images_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.batch_annotate_images requests: requests, parent: parent, labels: labels do |_result, response|
+        client_stub.batch_annotate_images requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        client_stub.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        client_stub.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_batch_annotate_files_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, batch_annotate_files_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
+        client_stub.batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        client_stub.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        client_stub.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -212,32 +212,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_async_batch_annotate_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, async_batch_annotate_images_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |_result, response|
+        client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |_result, response|
+        client_stub.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |_result, response|
+        client_stub.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, call_options) do |_result, response|
+        client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), call_options) do |_result, response|
+        client_stub.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_async_batch_annotate_files_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, async_batch_annotate_files_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
+        client_stub.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        client_stub.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        client_stub.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_annotate_images_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.batch_annotate_images requests: requests, parent: parent, labels: labels do |response, operation|
+      c.batch_annotate_images requests: requests, parent: parent, labels: labels do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      c.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_annotate_files_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
+      c.batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      c.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -212,40 +212,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, async_batch_annotate_images_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |response, operation|
+      c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |response, operation|
+      c.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |response, operation|
+      c.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -279,40 +279,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, async_batch_annotate_files_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
+      c.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      c.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_annotate_images_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.batch_annotate_images requests: requests, parent: parent, labels: labels do |response, operation|
+      client_stub.batch_annotate_images requests: requests, parent: parent, labels: labels do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      client_stub.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      client_stub.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      client_stub.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_annotate_files_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
+      client_stub.batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      client_stub.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      client_stub.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      client_stub.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -212,40 +212,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, async_batch_annotate_images_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |response, operation|
+      client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |response, operation|
+      client_stub.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |response, operation|
+      client_stub.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      client_stub.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), grpc_options) do |response, operation|
+      client_stub.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -279,40 +279,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, async_batch_annotate_files_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
+      client_stub.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      client_stub.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      client_stub.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      client_stub.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_rest_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_product_set_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |_result, response|
+        c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |_result, response|
+        c.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |_result, response|
+        c.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, call_options) do |_result, response|
+        c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), call_options) do |_result, response|
+        c.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_product_sets_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_product_sets_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -209,32 +209,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_product_set_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_product_set({ name: name }) do |_result, response|
+        c.get_product_set({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_product_set name: name do |_result, response|
+        c.get_product_set name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |_result, response|
+        c.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_product_set({ name: name }, call_options) do |_result, response|
+        c.get_product_set({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), call_options) do |_result, response|
+        c.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -264,32 +264,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_update_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_product_set_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }) do |_result, response|
+        c.update_product_set({ product_set: product_set, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.update_product_set product_set: product_set, update_mask: update_mask do |_result, response|
+        c.update_product_set product_set: product_set, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |_result, response|
+        c.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }, call_options) do |_result, response|
+        c.update_product_set({ product_set: product_set, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), call_options) do |_result, response|
+        c.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -318,32 +318,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_product_set_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_product_set({ name: name }) do |_result, response|
+        c.delete_product_set({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_product_set name: name do |_result, response|
+        c.delete_product_set name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |_result, response|
+        c.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_product_set({ name: name }, call_options) do |_result, response|
+        c.delete_product_set({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), call_options) do |_result, response|
+        c.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -374,32 +374,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_product_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_product({ parent: parent, product: product, product_id: product_id }) do |_result, response|
+        c.create_product({ parent: parent, product: product, product_id: product_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_product parent: parent, product: product, product_id: product_id do |_result, response|
+        c.create_product parent: parent, product: product, product_id: product_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |_result, response|
+        c.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_product({ parent: parent, product: product, product_id: product_id }, call_options) do |_result, response|
+        c.create_product({ parent: parent, product: product, product_id: product_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), call_options) do |_result, response|
+        c.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -430,32 +430,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_products_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_products_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_products parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_products parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_products({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -484,32 +484,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_product_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_product({ name: name }) do |_result, response|
+        c.get_product({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_product name: name do |_result, response|
+        c.get_product name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |_result, response|
+        c.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_product({ name: name }, call_options) do |_result, response|
+        c.get_product({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), call_options) do |_result, response|
+        c.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -539,32 +539,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_update_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_product_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.update_product({ product: product, update_mask: update_mask }) do |_result, response|
+        c.update_product({ product: product, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.update_product product: product, update_mask: update_mask do |_result, response|
+        c.update_product product: product, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |_result, response|
+        c.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.update_product({ product: product, update_mask: update_mask }, call_options) do |_result, response|
+        c.update_product({ product: product, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), call_options) do |_result, response|
+        c.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -593,32 +593,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_product_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_product({ name: name }) do |_result, response|
+        c.delete_product({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_product name: name do |_result, response|
+        c.delete_product name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |_result, response|
+        c.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_product({ name: name }, call_options) do |_result, response|
+        c.delete_product({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), call_options) do |_result, response|
+        c.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -649,32 +649,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_reference_image_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |_result, response|
+        c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |_result, response|
+        c.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |_result, response|
+        c.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, call_options) do |_result, response|
+        c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), call_options) do |_result, response|
+        c.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -703,32 +703,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_reference_image_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_reference_image({ name: name }) do |_result, response|
+        c.delete_reference_image({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_reference_image name: name do |_result, response|
+        c.delete_reference_image name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |_result, response|
+        c.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_reference_image({ name: name }, call_options) do |_result, response|
+        c.delete_reference_image({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), call_options) do |_result, response|
+        c.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -759,32 +759,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_reference_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_reference_images_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -813,32 +813,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_reference_image_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_reference_image({ name: name }) do |_result, response|
+        c.get_reference_image({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_reference_image name: name do |_result, response|
+        c.get_reference_image name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |_result, response|
+        c.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_reference_image({ name: name }, call_options) do |_result, response|
+        c.get_reference_image({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), call_options) do |_result, response|
+        c.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -868,32 +868,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_add_product_to_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, add_product_to_product_set_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.add_product_to_product_set({ name: name, product: product }) do |_result, response|
+        c.add_product_to_product_set({ name: name, product: product }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.add_product_to_product_set name: name, product: product do |_result, response|
+        c.add_product_to_product_set name: name, product: product do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |_result, response|
+        c.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.add_product_to_product_set({ name: name, product: product }, call_options) do |_result, response|
+        c.add_product_to_product_set({ name: name, product: product }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
+        c.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -923,32 +923,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_remove_product_from_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, remove_product_from_product_set_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.remove_product_from_product_set({ name: name, product: product }) do |_result, response|
+        c.remove_product_from_product_set({ name: name, product: product }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.remove_product_from_product_set name: name, product: product do |_result, response|
+        c.remove_product_from_product_set name: name, product: product do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |_result, response|
+        c.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.remove_product_from_product_set({ name: name, product: product }, call_options) do |_result, response|
+        c.remove_product_from_product_set({ name: name, product: product }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
+        c.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -979,32 +979,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_products_in_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_products_in_product_set_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -1034,32 +1034,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_import_product_sets_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, import_product_sets_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.import_product_sets({ parent: parent, input_config: input_config }) do |_result, response|
+        c.import_product_sets({ parent: parent, input_config: input_config }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.import_product_sets parent: parent, input_config: input_config do |_result, response|
+        c.import_product_sets parent: parent, input_config: input_config do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |_result, response|
+        c.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.import_product_sets({ parent: parent, input_config: input_config }, call_options) do |_result, response|
+        c.import_product_sets({ parent: parent, input_config: input_config }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), call_options) do |_result, response|
+        c.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -1090,32 +1090,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_purge_products_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, purge_products_client_stub do
         # Create client
-        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |_result, response|
+        c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |_result, response|
+        c.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |_result, response|
+        c.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, call_options) do |_result, response|
+        c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), call_options) do |_result, response|
+        c.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_rest_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |_result, response|
+        client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |_result, response|
+        client_stub.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |_result, response|
+        client_stub.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, call_options) do |_result, response|
+        client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), call_options) do |_result, response|
+        client_stub.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_product_sets_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_product_sets_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -209,32 +209,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_product_set({ name: name }) do |_result, response|
+        client_stub.get_product_set({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_product_set name: name do |_result, response|
+        client_stub.get_product_set name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |_result, response|
+        client_stub.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_product_set({ name: name }, call_options) do |_result, response|
+        client_stub.get_product_set({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -264,32 +264,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_update_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.update_product_set({ product_set: product_set, update_mask: update_mask }) do |_result, response|
+        client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.update_product_set product_set: product_set, update_mask: update_mask do |_result, response|
+        client_stub.update_product_set product_set: product_set, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |_result, response|
+        client_stub.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.update_product_set({ product_set: product_set, update_mask: update_mask }, call_options) do |_result, response|
+        client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), call_options) do |_result, response|
+        client_stub.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -318,32 +318,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_product_set({ name: name }) do |_result, response|
+        client_stub.delete_product_set({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_product_set name: name do |_result, response|
+        client_stub.delete_product_set name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |_result, response|
+        client_stub.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_product_set({ name: name }, call_options) do |_result, response|
+        client_stub.delete_product_set({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -374,32 +374,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_product({ parent: parent, product: product, product_id: product_id }) do |_result, response|
+        client_stub.create_product({ parent: parent, product: product, product_id: product_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_product parent: parent, product: product, product_id: product_id do |_result, response|
+        client_stub.create_product parent: parent, product: product, product_id: product_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |_result, response|
+        client_stub.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_product({ parent: parent, product: product, product_id: product_id }, call_options) do |_result, response|
+        client_stub.create_product({ parent: parent, product: product, product_id: product_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), call_options) do |_result, response|
+        client_stub.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -430,32 +430,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_products_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_products_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_products parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_products parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_products({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -484,32 +484,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_product({ name: name }) do |_result, response|
+        client_stub.get_product({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_product name: name do |_result, response|
+        client_stub.get_product name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |_result, response|
+        client_stub.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_product({ name: name }, call_options) do |_result, response|
+        client_stub.get_product({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -539,32 +539,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_update_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.update_product({ product: product, update_mask: update_mask }) do |_result, response|
+        client_stub.update_product({ product: product, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.update_product product: product, update_mask: update_mask do |_result, response|
+        client_stub.update_product product: product, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |_result, response|
+        client_stub.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.update_product({ product: product, update_mask: update_mask }, call_options) do |_result, response|
+        client_stub.update_product({ product: product, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), call_options) do |_result, response|
+        client_stub.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -593,32 +593,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_product({ name: name }) do |_result, response|
+        client_stub.delete_product({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_product name: name do |_result, response|
+        client_stub.delete_product name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |_result, response|
+        client_stub.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_product({ name: name }, call_options) do |_result, response|
+        client_stub.delete_product({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -649,32 +649,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_reference_image_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |_result, response|
+        client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |_result, response|
+        client_stub.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |_result, response|
+        client_stub.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, call_options) do |_result, response|
+        client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), call_options) do |_result, response|
+        client_stub.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -703,32 +703,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_reference_image_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_reference_image({ name: name }) do |_result, response|
+        client_stub.delete_reference_image({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_reference_image name: name do |_result, response|
+        client_stub.delete_reference_image name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |_result, response|
+        client_stub.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_reference_image({ name: name }, call_options) do |_result, response|
+        client_stub.delete_reference_image({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -759,32 +759,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_reference_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_reference_images_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -813,32 +813,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_reference_image_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_reference_image({ name: name }) do |_result, response|
+        client_stub.get_reference_image({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_reference_image name: name do |_result, response|
+        client_stub.get_reference_image name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |_result, response|
+        client_stub.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_reference_image({ name: name }, call_options) do |_result, response|
+        client_stub.get_reference_image({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -868,32 +868,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_add_product_to_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, add_product_to_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.add_product_to_product_set({ name: name, product: product }) do |_result, response|
+        client_stub.add_product_to_product_set({ name: name, product: product }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.add_product_to_product_set name: name, product: product do |_result, response|
+        client_stub.add_product_to_product_set name: name, product: product do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |_result, response|
+        client_stub.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.add_product_to_product_set({ name: name, product: product }, call_options) do |_result, response|
+        client_stub.add_product_to_product_set({ name: name, product: product }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
+        client_stub.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -923,32 +923,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_remove_product_from_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, remove_product_from_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.remove_product_from_product_set({ name: name, product: product }) do |_result, response|
+        client_stub.remove_product_from_product_set({ name: name, product: product }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.remove_product_from_product_set name: name, product: product do |_result, response|
+        client_stub.remove_product_from_product_set name: name, product: product do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |_result, response|
+        client_stub.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.remove_product_from_product_set({ name: name, product: product }, call_options) do |_result, response|
+        client_stub.remove_product_from_product_set({ name: name, product: product }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
+        client_stub.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -979,32 +979,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_products_in_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_products_in_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -1034,32 +1034,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_import_product_sets_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, import_product_sets_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.import_product_sets({ parent: parent, input_config: input_config }) do |_result, response|
+        client_stub.import_product_sets({ parent: parent, input_config: input_config }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.import_product_sets parent: parent, input_config: input_config do |_result, response|
+        client_stub.import_product_sets parent: parent, input_config: input_config do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |_result, response|
+        client_stub.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.import_product_sets({ parent: parent, input_config: input_config }, call_options) do |_result, response|
+        client_stub.import_product_sets({ parent: parent, input_config: input_config }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), call_options) do |_result, response|
+        client_stub.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -1090,32 +1090,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_purge_products_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, purge_products_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |_result, response|
+        client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |_result, response|
+        client_stub.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |_result, response|
+        client_stub.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, call_options) do |_result, response|
+        client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), call_options) do |_result, response|
+        client_stub.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
+      client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
+      client_stub.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |response, operation|
+      client_stub.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, grpc_options) do |response, operation|
+      client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), grpc_options) do |response, operation|
+      client_stub.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,40 +148,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_product_sets_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -211,36 +211,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_product_set({ name: name }) do |response, operation|
+      client_stub.get_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_product_set name: name do |response, operation|
+      client_stub.get_product_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |response, operation|
+      client_stub.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_product_set({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_product_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -271,36 +271,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
+      client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
+      client_stub.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |response, operation|
+      client_stub.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_product_set({ product_set: product_set, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_product_set({ name: name }) do |response, operation|
+      client_stub.delete_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_product_set name: name do |response, operation|
+      client_stub.delete_product_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |response, operation|
+      client_stub.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_product_set({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_product_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,36 +391,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
+      client_stub.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_product parent: parent, product: product, product_id: product_id do |response, operation|
+      client_stub.create_product parent: parent, product: product, product_id: product_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |response, operation|
+      client_stub.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_product({ parent: parent, product: product, product_id: product_id }, grpc_options) do |response, operation|
+      client_stub.create_product({ parent: parent, product: product, product_id: product_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), grpc_options) do |response, operation|
+      client_stub.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -453,40 +453,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_products_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_products({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -516,36 +516,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_product({ name: name }) do |response, operation|
+      client_stub.get_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_product name: name do |response, operation|
+      client_stub.get_product name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |response, operation|
+      client_stub.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_product({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_product({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -576,36 +576,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_product({ product: product, update_mask: update_mask }) do |response, operation|
+      client_stub.update_product({ product: product, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_product product: product, update_mask: update_mask do |response, operation|
+      client_stub.update_product product: product, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |response, operation|
+      client_stub.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_product({ product: product, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_product({ product: product, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -634,36 +634,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_product({ name: name }) do |response, operation|
+      client_stub.delete_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_product name: name do |response, operation|
+      client_stub.delete_product name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |response, operation|
+      client_stub.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_product({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_product({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -696,36 +696,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_reference_image_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
+      client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
+      client_stub.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |response, operation|
+      client_stub.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, grpc_options) do |response, operation|
+      client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), grpc_options) do |response, operation|
+      client_stub.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -754,36 +754,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_reference_image_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_reference_image({ name: name }) do |response, operation|
+      client_stub.delete_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_reference_image name: name do |response, operation|
+      client_stub.delete_reference_image name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |response, operation|
+      client_stub.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_reference_image({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_reference_image({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -816,40 +816,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_reference_images_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -879,36 +879,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_reference_image_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_reference_image({ name: name }) do |response, operation|
+      client_stub.get_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_reference_image name: name do |response, operation|
+      client_stub.get_reference_image name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |response, operation|
+      client_stub.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_reference_image({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_reference_image({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -939,36 +939,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, add_product_to_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.add_product_to_product_set({ name: name, product: product }) do |response, operation|
+      client_stub.add_product_to_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.add_product_to_product_set name: name, product: product do |response, operation|
+      client_stub.add_product_to_product_set name: name, product: product do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |response, operation|
+      client_stub.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.add_product_to_product_set({ name: name, product: product }, grpc_options) do |response, operation|
+      client_stub.add_product_to_product_set({ name: name, product: product }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
+      client_stub.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -999,36 +999,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, remove_product_from_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
+      client_stub.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.remove_product_from_product_set name: name, product: product do |response, operation|
+      client_stub.remove_product_from_product_set name: name, product: product do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |response, operation|
+      client_stub.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.remove_product_from_product_set({ name: name, product: product }, grpc_options) do |response, operation|
+      client_stub.remove_product_from_product_set({ name: name, product: product }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
+      client_stub.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -1061,40 +1061,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_products_in_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -1126,40 +1126,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, import_product_sets_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
+      client_stub.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.import_product_sets parent: parent, input_config: input_config do |response, operation|
+      client_stub.import_product_sets parent: parent, input_config: input_config do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |response, operation|
+      client_stub.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.import_product_sets({ parent: parent, input_config: input_config }, grpc_options) do |response, operation|
+      client_stub.import_product_sets({ parent: parent, input_config: input_config }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), grpc_options) do |response, operation|
+      client_stub.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -1194,40 +1194,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, purge_products_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |response, operation|
+      client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |response, operation|
+      client_stub.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |response, operation|
+      client_stub.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, grpc_options) do |response, operation|
+      client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), grpc_options) do |response, operation|
+      client_stub.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_product_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
+      c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
+      c.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |response, operation|
+      c.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, grpc_options) do |response, operation|
+      c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), grpc_options) do |response, operation|
+      c.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,40 +148,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_product_sets_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -211,36 +211,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_product_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_product_set({ name: name }) do |response, operation|
+      c.get_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_product_set name: name do |response, operation|
+      c.get_product_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |response, operation|
+      c.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_product_set({ name: name }, grpc_options) do |response, operation|
+      c.get_product_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -271,36 +271,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_product_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
+      c.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
+      c.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |response, operation|
+      c.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_product_set({ product_set: product_set, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_product_set({ product_set: product_set, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_product_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_product_set({ name: name }) do |response, operation|
+      c.delete_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_product_set name: name do |response, operation|
+      c.delete_product_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |response, operation|
+      c.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_product_set({ name: name }, grpc_options) do |response, operation|
+      c.delete_product_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,36 +391,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_product_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
+      c.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_product parent: parent, product: product, product_id: product_id do |response, operation|
+      c.create_product parent: parent, product: product, product_id: product_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |response, operation|
+      c.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_product({ parent: parent, product: product, product_id: product_id }, grpc_options) do |response, operation|
+      c.create_product({ parent: parent, product: product, product_id: product_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), grpc_options) do |response, operation|
+      c.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -453,40 +453,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_products_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_products({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_products({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -516,36 +516,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_product_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_product({ name: name }) do |response, operation|
+      c.get_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_product name: name do |response, operation|
+      c.get_product name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |response, operation|
+      c.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_product({ name: name }, grpc_options) do |response, operation|
+      c.get_product({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -576,36 +576,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_product_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_product({ product: product, update_mask: update_mask }) do |response, operation|
+      c.update_product({ product: product, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_product product: product, update_mask: update_mask do |response, operation|
+      c.update_product product: product, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |response, operation|
+      c.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_product({ product: product, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_product({ product: product, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -634,36 +634,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_product_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_product({ name: name }) do |response, operation|
+      c.delete_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_product name: name do |response, operation|
+      c.delete_product name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |response, operation|
+      c.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_product({ name: name }, grpc_options) do |response, operation|
+      c.delete_product({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -696,36 +696,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_reference_image_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
+      c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
+      c.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |response, operation|
+      c.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, grpc_options) do |response, operation|
+      c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), grpc_options) do |response, operation|
+      c.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -754,36 +754,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_reference_image_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_reference_image({ name: name }) do |response, operation|
+      c.delete_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_reference_image name: name do |response, operation|
+      c.delete_reference_image name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |response, operation|
+      c.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_reference_image({ name: name }, grpc_options) do |response, operation|
+      c.delete_reference_image({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -816,40 +816,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_reference_images_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -879,36 +879,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_reference_image_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_reference_image({ name: name }) do |response, operation|
+      c.get_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_reference_image name: name do |response, operation|
+      c.get_reference_image name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |response, operation|
+      c.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_reference_image({ name: name }, grpc_options) do |response, operation|
+      c.get_reference_image({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -939,36 +939,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, add_product_to_product_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.add_product_to_product_set({ name: name, product: product }) do |response, operation|
+      c.add_product_to_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.add_product_to_product_set name: name, product: product do |response, operation|
+      c.add_product_to_product_set name: name, product: product do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |response, operation|
+      c.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.add_product_to_product_set({ name: name, product: product }, grpc_options) do |response, operation|
+      c.add_product_to_product_set({ name: name, product: product }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
+      c.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -999,36 +999,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, remove_product_from_product_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
+      c.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.remove_product_from_product_set name: name, product: product do |response, operation|
+      c.remove_product_from_product_set name: name, product: product do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |response, operation|
+      c.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.remove_product_from_product_set({ name: name, product: product }, grpc_options) do |response, operation|
+      c.remove_product_from_product_set({ name: name, product: product }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
+      c.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -1061,40 +1061,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_products_in_product_set_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -1126,40 +1126,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, import_product_sets_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
+      c.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.import_product_sets parent: parent, input_config: input_config do |response, operation|
+      c.import_product_sets parent: parent, input_config: input_config do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |response, operation|
+      c.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.import_product_sets({ parent: parent, input_config: input_config }, grpc_options) do |response, operation|
+      c.import_product_sets({ parent: parent, input_config: input_config }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), grpc_options) do |response, operation|
+      c.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -1194,40 +1194,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, purge_products_client_stub do
       # Create client
-      client_stub = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |response, operation|
+      c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |response, operation|
+      c.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |response, operation|
+      c.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, grpc_options) do |response, operation|
+      c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), grpc_options) do |response, operation|
+      c.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
@@ -88,30 +88,30 @@ class ::So::Much::Trash::DeprecatedService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, deprecated_get_client_stub do
       # Create client
-      client = ::So::Much::Trash::DeprecatedService::Client.new do |config|
+      client_stub = ::So::Much::Trash::DeprecatedService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.deprecated_get({  }) do |response, operation|
+      client_stub.deprecated_get({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.deprecated_get ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      client_stub.deprecated_get ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.deprecated_get({  }, grpc_options) do |response, operation|
+      client_stub.deprecated_get({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.deprecated_get(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      client_stub.deprecated_get(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
@@ -88,30 +88,30 @@ class ::So::Much::Trash::DeprecatedService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, deprecated_get_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::DeprecatedService::Client.new do |config|
+      c = ::So::Much::Trash::DeprecatedService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.deprecated_get({  }) do |response, operation|
+      c.deprecated_get({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.deprecated_get ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      c.deprecated_get ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.deprecated_get({  }, grpc_options) do |response, operation|
+      c.deprecated_get({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.deprecated_get(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      c.deprecated_get(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
@@ -99,40 +99,40 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
@@ -99,40 +99,40 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      c = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      c = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      c = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      c = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Operations.new do |config|
+      c = ::So::Much::Trash::GarbageService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -88,30 +88,30 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_empty_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_empty_garbage({  }) do |response, operation|
+      c.get_empty_garbage({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      c.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_empty_garbage({  }, grpc_options) do |response, operation|
+      c.get_empty_garbage({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      c.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -140,36 +140,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_simple_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_simple_garbage({ name: name }) do |response, operation|
+      c.get_simple_garbage({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_simple_garbage name: name do |response, operation|
+      c.get_simple_garbage name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_simple_garbage ::So::Much::Trash::SimpleGarbage.new(name: name) do |response, operation|
+      c.get_simple_garbage ::So::Much::Trash::SimpleGarbage.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_simple_garbage({ name: name }, grpc_options) do |response, operation|
+      c.get_simple_garbage({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_simple_garbage(::So::Much::Trash::SimpleGarbage.new(name: name), grpc_options) do |response, operation|
+      c.get_simple_garbage(::So::Much::Trash::SimpleGarbage.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -220,36 +220,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_specific_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }) do |response, operation|
+      c.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_specific_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested do |response, operation|
+      c.get_specific_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_specific_garbage ::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested) do |response, operation|
+      c.get_specific_garbage ::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }, grpc_options) do |response, operation|
+      c.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_specific_garbage(::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested), grpc_options) do |response, operation|
+      c.get_specific_garbage(::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -298,36 +298,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_nested_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }) do |response, operation|
+      c.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_nested_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum do |response, operation|
+      c.get_nested_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_nested_garbage ::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum) do |response, operation|
+      c.get_nested_garbage ::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }, grpc_options) do |response, operation|
+      c.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_nested_garbage(::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum), grpc_options) do |response, operation|
+      c.get_nested_garbage(::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -376,36 +376,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_repeated_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }) do |response, operation|
+      c.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_repeated_garbage repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum do |response, operation|
+      c.get_repeated_garbage repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_repeated_garbage ::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum) do |response, operation|
+      c.get_repeated_garbage ::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }, grpc_options) do |response, operation|
+      c.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_repeated_garbage(::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum), grpc_options) do |response, operation|
+      c.get_repeated_garbage(::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -474,36 +474,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_typical_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }) do |response, operation|
+      c.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_typical_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param do |response, operation|
+      c.get_typical_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_typical_garbage ::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param) do |response, operation|
+      c.get_typical_garbage ::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }, grpc_options) do |response, operation|
+      c.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_typical_garbage(::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param), grpc_options) do |response, operation|
+      c.get_typical_garbage(::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -532,36 +532,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_typical_garbage_by_request_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_typical_garbage_by_request({ name: name }) do |response, operation|
+      c.get_typical_garbage_by_request({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_typical_garbage_by_request name: name do |response, operation|
+      c.get_typical_garbage_by_request name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_typical_garbage_by_request ::So::Much::Trash::GetTypicalGarbageRequest.new(name: name) do |response, operation|
+      c.get_typical_garbage_by_request ::So::Much::Trash::GetTypicalGarbageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_typical_garbage_by_request({ name: name }, grpc_options) do |response, operation|
+      c.get_typical_garbage_by_request({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_typical_garbage_by_request(::So::Much::Trash::GetTypicalGarbageRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_typical_garbage_by_request(::So::Much::Trash::GetTypicalGarbageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -590,36 +590,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_complex_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_complex_garbage({ layer1: layer1 }) do |response, operation|
+      c.get_complex_garbage({ layer1: layer1 }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_complex_garbage layer1: layer1 do |response, operation|
+      c.get_complex_garbage layer1: layer1 do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_complex_garbage ::So::Much::Trash::ComplexGarbage.new(layer1: layer1) do |response, operation|
+      c.get_complex_garbage ::So::Much::Trash::ComplexGarbage.new(layer1: layer1) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_complex_garbage({ layer1: layer1 }, grpc_options) do |response, operation|
+      c.get_complex_garbage({ layer1: layer1 }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_complex_garbage(::So::Much::Trash::ComplexGarbage.new(layer1: layer1), grpc_options) do |response, operation|
+      c.get_complex_garbage(::So::Much::Trash::ComplexGarbage.new(layer1: layer1), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -650,36 +650,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_garbage_node_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_garbage_node({ data: data, parent: parent }) do |response, operation|
+      c.get_garbage_node({ data: data, parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_garbage_node data: data, parent: parent do |response, operation|
+      c.get_garbage_node data: data, parent: parent do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_garbage_node ::So::Much::Trash::GarbageNode.new(data: data, parent: parent) do |response, operation|
+      c.get_garbage_node ::So::Much::Trash::GarbageNode.new(data: data, parent: parent) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_garbage_node({ data: data, parent: parent }, grpc_options) do |response, operation|
+      c.get_garbage_node({ data: data, parent: parent }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_garbage_node(::So::Much::Trash::GarbageNode.new(data: data, parent: parent), grpc_options) do |response, operation|
+      c.get_garbage_node(::So::Much::Trash::GarbageNode.new(data: data, parent: parent), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -712,40 +712,40 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_paged_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_paged_garbage garbage: garbage, page_size: page_size, page_token: page_token do |response, operation|
+      c.get_paged_garbage garbage: garbage, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_paged_garbage ::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token) do |response, operation|
+      c.get_paged_garbage ::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_paged_garbage(::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.get_paged_garbage(::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -775,40 +775,40 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, long_running_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.long_running_garbage({ garbage: garbage }) do |response, operation|
+      c.long_running_garbage({ garbage: garbage }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.long_running_garbage garbage: garbage do |response, operation|
+      c.long_running_garbage garbage: garbage do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.long_running_garbage ::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage) do |response, operation|
+      c.long_running_garbage ::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.long_running_garbage({ garbage: garbage }, grpc_options) do |response, operation|
+      c.long_running_garbage({ garbage: garbage }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.long_running_garbage(::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
+      c.long_running_garbage(::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -838,7 +838,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, client_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -846,7 +846,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.client_garbage enum_input do |response, operation|
+      c.client_garbage enum_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -855,7 +855,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client_stub.client_garbage stream_input do |response, operation|
+      c.client_garbage stream_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -867,7 +867,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.client_garbage enum_input, grpc_options do |response, operation|
+      c.client_garbage enum_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -876,7 +876,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client_stub.client_garbage stream_input, grpc_options do |response, operation|
+      c.client_garbage stream_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -914,12 +914,12 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, server_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.server_garbage({ garbage: garbage }) do |response, operation|
+      c.server_garbage({ garbage: garbage }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -928,7 +928,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client_stub.server_garbage garbage: garbage do |response, operation|
+      c.server_garbage garbage: garbage do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -937,7 +937,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client_stub.server_garbage ::So::Much::Trash::ListGarbageRequest.new(garbage: garbage) do |response, operation|
+      c.server_garbage ::So::Much::Trash::ListGarbageRequest.new(garbage: garbage) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -946,7 +946,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client_stub.server_garbage({ garbage: garbage }, grpc_options) do |response, operation|
+      c.server_garbage({ garbage: garbage }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -955,7 +955,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client_stub.server_garbage(::So::Much::Trash::ListGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
+      c.server_garbage(::So::Much::Trash::ListGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -987,7 +987,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, bidi_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -995,7 +995,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.bidi_garbage enum_input do |response, operation|
+      c.bidi_garbage enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1007,7 +1007,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client_stub.bidi_garbage stream_input do |response, operation|
+      c.bidi_garbage stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1022,7 +1022,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.bidi_garbage enum_input, grpc_options do |response, operation|
+      c.bidi_garbage enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1034,7 +1034,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client_stub.bidi_garbage stream_input, grpc_options do |response, operation|
+      c.bidi_garbage stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1093,7 +1093,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, bidi_typical_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -1101,7 +1101,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.bidi_typical_garbage enum_input do |response, operation|
+      c.bidi_typical_garbage enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1113,7 +1113,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       stream_input = Gapic::StreamInput.new
-      client_stub.bidi_typical_garbage stream_input do |response, operation|
+      c.bidi_typical_garbage stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1128,7 +1128,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.bidi_typical_garbage enum_input, grpc_options do |response, operation|
+      c.bidi_typical_garbage enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1140,7 +1140,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       stream_input = Gapic::StreamInput.new
-      client_stub.bidi_typical_garbage stream_input, grpc_options do |response, operation|
+      c.bidi_typical_garbage stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1201,30 +1201,30 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, call_send_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
+      c = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.call_send({  }) do |response, operation|
+      c.call_send({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.call_send ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      c.call_send ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.call_send({  }, grpc_options) do |response, operation|
+      c.call_send({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.call_send(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      c.call_send(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -88,30 +88,30 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_empty_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_empty_garbage({  }) do |response, operation|
+      client_stub.get_empty_garbage({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      client_stub.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_empty_garbage({  }, grpc_options) do |response, operation|
+      client_stub.get_empty_garbage({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      client_stub.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -140,36 +140,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_simple_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_simple_garbage({ name: name }) do |response, operation|
+      client_stub.get_simple_garbage({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_simple_garbage name: name do |response, operation|
+      client_stub.get_simple_garbage name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_simple_garbage ::So::Much::Trash::SimpleGarbage.new(name: name) do |response, operation|
+      client_stub.get_simple_garbage ::So::Much::Trash::SimpleGarbage.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_simple_garbage({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_simple_garbage({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_simple_garbage(::So::Much::Trash::SimpleGarbage.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_simple_garbage(::So::Much::Trash::SimpleGarbage.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -220,36 +220,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_specific_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }) do |response, operation|
+      client_stub.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_specific_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested do |response, operation|
+      client_stub.get_specific_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_specific_garbage ::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested) do |response, operation|
+      client_stub.get_specific_garbage ::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }, grpc_options) do |response, operation|
+      client_stub.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_specific_garbage(::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested), grpc_options) do |response, operation|
+      client_stub.get_specific_garbage(::So::Much::Trash::SpecificGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -298,36 +298,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_nested_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }) do |response, operation|
+      client_stub.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_nested_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum do |response, operation|
+      client_stub.get_nested_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_nested_garbage ::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum) do |response, operation|
+      client_stub.get_nested_garbage ::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }, grpc_options) do |response, operation|
+      client_stub.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_nested_garbage(::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum), grpc_options) do |response, operation|
+      client_stub.get_nested_garbage(::So::Much::Trash::SpecificGarbage::NestedGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -376,36 +376,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_repeated_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }) do |response, operation|
+      client_stub.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_repeated_garbage repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum do |response, operation|
+      client_stub.get_repeated_garbage repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_repeated_garbage ::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum) do |response, operation|
+      client_stub.get_repeated_garbage ::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }, grpc_options) do |response, operation|
+      client_stub.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_repeated_garbage(::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum), grpc_options) do |response, operation|
+      client_stub.get_repeated_garbage(::So::Much::Trash::RepeatedGarbage.new(repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -474,36 +474,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_typical_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }) do |response, operation|
+      client_stub.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_typical_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param do |response, operation|
+      client_stub.get_typical_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_typical_garbage ::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param) do |response, operation|
+      client_stub.get_typical_garbage ::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }, grpc_options) do |response, operation|
+      client_stub.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_typical_garbage(::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param), grpc_options) do |response, operation|
+      client_stub.get_typical_garbage(::So::Much::Trash::TypicalGarbage.new(name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -532,36 +532,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_typical_garbage_by_request_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_typical_garbage_by_request({ name: name }) do |response, operation|
+      client_stub.get_typical_garbage_by_request({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_typical_garbage_by_request name: name do |response, operation|
+      client_stub.get_typical_garbage_by_request name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_typical_garbage_by_request ::So::Much::Trash::GetTypicalGarbageRequest.new(name: name) do |response, operation|
+      client_stub.get_typical_garbage_by_request ::So::Much::Trash::GetTypicalGarbageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_typical_garbage_by_request({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_typical_garbage_by_request({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_typical_garbage_by_request(::So::Much::Trash::GetTypicalGarbageRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_typical_garbage_by_request(::So::Much::Trash::GetTypicalGarbageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -590,36 +590,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_complex_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_complex_garbage({ layer1: layer1 }) do |response, operation|
+      client_stub.get_complex_garbage({ layer1: layer1 }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_complex_garbage layer1: layer1 do |response, operation|
+      client_stub.get_complex_garbage layer1: layer1 do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_complex_garbage ::So::Much::Trash::ComplexGarbage.new(layer1: layer1) do |response, operation|
+      client_stub.get_complex_garbage ::So::Much::Trash::ComplexGarbage.new(layer1: layer1) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_complex_garbage({ layer1: layer1 }, grpc_options) do |response, operation|
+      client_stub.get_complex_garbage({ layer1: layer1 }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_complex_garbage(::So::Much::Trash::ComplexGarbage.new(layer1: layer1), grpc_options) do |response, operation|
+      client_stub.get_complex_garbage(::So::Much::Trash::ComplexGarbage.new(layer1: layer1), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -650,36 +650,36 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_garbage_node_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_garbage_node({ data: data, parent: parent }) do |response, operation|
+      client_stub.get_garbage_node({ data: data, parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_garbage_node data: data, parent: parent do |response, operation|
+      client_stub.get_garbage_node data: data, parent: parent do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_garbage_node ::So::Much::Trash::GarbageNode.new(data: data, parent: parent) do |response, operation|
+      client_stub.get_garbage_node ::So::Much::Trash::GarbageNode.new(data: data, parent: parent) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_garbage_node({ data: data, parent: parent }, grpc_options) do |response, operation|
+      client_stub.get_garbage_node({ data: data, parent: parent }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_garbage_node(::So::Much::Trash::GarbageNode.new(data: data, parent: parent), grpc_options) do |response, operation|
+      client_stub.get_garbage_node(::So::Much::Trash::GarbageNode.new(data: data, parent: parent), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -712,40 +712,40 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_paged_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_paged_garbage garbage: garbage, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.get_paged_garbage garbage: garbage, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_paged_garbage ::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.get_paged_garbage ::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_paged_garbage(::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.get_paged_garbage(::So::Much::Trash::PagedGarbageRequest.new(garbage: garbage, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -775,40 +775,40 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, long_running_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.long_running_garbage({ garbage: garbage }) do |response, operation|
+      client_stub.long_running_garbage({ garbage: garbage }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.long_running_garbage garbage: garbage do |response, operation|
+      client_stub.long_running_garbage garbage: garbage do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.long_running_garbage ::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage) do |response, operation|
+      client_stub.long_running_garbage ::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.long_running_garbage({ garbage: garbage }, grpc_options) do |response, operation|
+      client_stub.long_running_garbage({ garbage: garbage }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.long_running_garbage(::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
+      client_stub.long_running_garbage(::So::Much::Trash::LongRunningGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -838,7 +838,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, client_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -846,7 +846,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client.client_garbage enum_input do |response, operation|
+      client_stub.client_garbage enum_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -855,7 +855,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client.client_garbage stream_input do |response, operation|
+      client_stub.client_garbage stream_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -867,7 +867,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client.client_garbage enum_input, grpc_options do |response, operation|
+      client_stub.client_garbage enum_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -876,7 +876,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client.client_garbage stream_input, grpc_options do |response, operation|
+      client_stub.client_garbage stream_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -914,12 +914,12 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, server_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.server_garbage({ garbage: garbage }) do |response, operation|
+      client_stub.server_garbage({ garbage: garbage }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -928,7 +928,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client.server_garbage garbage: garbage do |response, operation|
+      client_stub.server_garbage garbage: garbage do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -937,7 +937,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client.server_garbage ::So::Much::Trash::ListGarbageRequest.new(garbage: garbage) do |response, operation|
+      client_stub.server_garbage ::So::Much::Trash::ListGarbageRequest.new(garbage: garbage) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -946,7 +946,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client.server_garbage({ garbage: garbage }, grpc_options) do |response, operation|
+      client_stub.server_garbage({ garbage: garbage }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -955,7 +955,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client.server_garbage(::So::Much::Trash::ListGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
+      client_stub.server_garbage(::So::Much::Trash::ListGarbageRequest.new(garbage: garbage), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -987,7 +987,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, bidi_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -995,7 +995,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client.bidi_garbage enum_input do |response, operation|
+      client_stub.bidi_garbage enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1007,7 +1007,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client.bidi_garbage stream_input do |response, operation|
+      client_stub.bidi_garbage stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1022,7 +1022,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       enum_input = [request_hash, request_proto].to_enum
-      client.bidi_garbage enum_input, grpc_options do |response, operation|
+      client_stub.bidi_garbage enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1034,7 +1034,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { garbage: garbage }
       request_proto = ::So::Much::Trash::ListGarbageRequest.new garbage: garbage
       stream_input = Gapic::StreamInput.new
-      client.bidi_garbage stream_input, grpc_options do |response, operation|
+      client_stub.bidi_garbage stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::GarbageItem, r
@@ -1093,7 +1093,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, bidi_typical_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -1101,7 +1101,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       enum_input = [request_hash, request_proto].to_enum
-      client.bidi_typical_garbage enum_input do |response, operation|
+      client_stub.bidi_typical_garbage enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1113,7 +1113,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       stream_input = Gapic::StreamInput.new
-      client.bidi_typical_garbage stream_input do |response, operation|
+      client_stub.bidi_typical_garbage stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1128,7 +1128,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       enum_input = [request_hash, request_proto].to_enum
-      client.bidi_typical_garbage enum_input, grpc_options do |response, operation|
+      client_stub.bidi_typical_garbage enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1140,7 +1140,7 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       request_hash = { name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param }
       request_proto = ::So::Much::Trash::TypicalGarbage.new name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum, amap: amap, oneof_singular_str: oneof_singular_str, oneof_pair_int32: oneof_pair_int32, oneof_multiple_message: oneof_multiple_message, optional_int32: optional_int32, case: case_param
       stream_input = Gapic::StreamInput.new
-      client.bidi_typical_garbage stream_input, grpc_options do |response, operation|
+      client_stub.bidi_typical_garbage stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::So::Much::Trash::TypicalGarbage, r
@@ -1201,30 +1201,30 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, call_send_client_stub do
       # Create client
-      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+      client_stub = ::So::Much::Trash::GarbageService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.call_send({  }) do |response, operation|
+      client_stub.call_send({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.call_send ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      client_stub.call_send ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.call_send({  }, grpc_options) do |response, operation|
+      client_stub.call_send({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.call_send(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      client_stub.call_send(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
@@ -94,36 +94,36 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, set_iam_policy_client_stub do
       # Create client
-      client = ::So::Much::Trash::IAMPolicy::Client.new do |config|
+      client_stub = ::So::Much::Trash::IAMPolicy::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
+      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
+      client_stub.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
+      client_stub.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -154,36 +154,36 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_iam_policy_client_stub do
       # Create client
-      client = ::So::Much::Trash::IAMPolicy::Client.new do |config|
+      client_stub = ::So::Much::Trash::IAMPolicy::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_iam_policy({ resource: resource, options: options }) do |response, operation|
+      client_stub.get_iam_policy({ resource: resource, options: options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_iam_policy resource: resource, options: options do |response, operation|
+      client_stub.get_iam_policy resource: resource, options: options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
+      client_stub.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
+      client_stub.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
+      client_stub.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -214,36 +214,36 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, test_iam_permissions_client_stub do
       # Create client
-      client = ::So::Much::Trash::IAMPolicy::Client.new do |config|
+      client_stub = ::So::Much::Trash::IAMPolicy::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
+      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
+      client_stub.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
+      client_stub.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
+      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
+      client_stub.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
@@ -94,36 +94,36 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, set_iam_policy_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::IAMPolicy::Client.new do |config|
+      c = ::So::Much::Trash::IAMPolicy::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
+      c.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
+      c.set_iam_policy resource: resource, policy: policy, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
+      c.set_iam_policy ::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.set_iam_policy({ resource: resource, policy: policy, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
+      c.set_iam_policy(::Google::Iam::V1::SetIamPolicyRequest.new(resource: resource, policy: policy, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -154,36 +154,36 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_iam_policy_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::IAMPolicy::Client.new do |config|
+      c = ::So::Much::Trash::IAMPolicy::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_iam_policy({ resource: resource, options: options }) do |response, operation|
+      c.get_iam_policy({ resource: resource, options: options }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_iam_policy resource: resource, options: options do |response, operation|
+      c.get_iam_policy resource: resource, options: options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
+      c.get_iam_policy ::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
+      c.get_iam_policy({ resource: resource, options: options }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
+      c.get_iam_policy(::Google::Iam::V1::GetIamPolicyRequest.new(resource: resource, options: options), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -214,36 +214,36 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, test_iam_permissions_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::IAMPolicy::Client.new do |config|
+      c = ::So::Much::Trash::IAMPolicy::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
+      c.test_iam_permissions({ resource: resource, permissions: permissions }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
+      c.test_iam_permissions resource: resource, permissions: permissions do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
+      c.test_iam_permissions ::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
+      c.test_iam_permissions({ resource: resource, permissions: permissions }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
+      c.test_iam_permissions(::Google::Iam::V1::TestIamPermissionsRequest.new(resource: resource, permissions: permissions), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
@@ -88,30 +88,30 @@ class ::So::Much::Trash::ReallyRenamedService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_empty_garbage_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::ReallyRenamedService::Client.new do |config|
+      c = ::So::Much::Trash::ReallyRenamedService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_empty_garbage({  }) do |response, operation|
+      c.get_empty_garbage({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      c.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_empty_garbage({  }, grpc_options) do |response, operation|
+      c.get_empty_garbage({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      c.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
@@ -88,30 +88,30 @@ class ::So::Much::Trash::ReallyRenamedService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_empty_garbage_client_stub do
       # Create client
-      client = ::So::Much::Trash::ReallyRenamedService::Client.new do |config|
+      client_stub = ::So::Much::Trash::ReallyRenamedService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_empty_garbage({  }) do |response, operation|
+      client_stub.get_empty_garbage({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
+      client_stub.get_empty_garbage ::So::Much::Trash::EmptyGarbage.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_empty_garbage({  }, grpc_options) do |response, operation|
+      client_stub.get_empty_garbage({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
+      client_stub.get_empty_garbage(::So::Much::Trash::EmptyGarbage.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
@@ -94,36 +94,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, simple_pattern_method_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      c = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
+      c.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.simple_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
+      c.simple_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.simple_pattern_method ::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
+      c.simple_pattern_method ::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
+      c.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.simple_pattern_method(::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
+      c.simple_pattern_method(::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -156,36 +156,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, complex_pattern_method_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      c = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
+      c.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.complex_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
+      c.complex_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.complex_pattern_method ::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
+      c.complex_pattern_method ::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
+      c.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.complex_pattern_method(::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
+      c.complex_pattern_method(::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -214,36 +214,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, resource_name_pattern_method_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      c = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.resource_name_pattern_method({ name: name }) do |response, operation|
+      c.resource_name_pattern_method({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.resource_name_pattern_method name: name do |response, operation|
+      c.resource_name_pattern_method name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.resource_name_pattern_method ::So::Much::Trash::ResourceNamePatternRequest.new(name: name) do |response, operation|
+      c.resource_name_pattern_method ::So::Much::Trash::ResourceNamePatternRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.resource_name_pattern_method({ name: name }, grpc_options) do |response, operation|
+      c.resource_name_pattern_method({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.resource_name_pattern_method(::So::Much::Trash::ResourceNamePatternRequest.new(name: name), grpc_options) do |response, operation|
+      c.resource_name_pattern_method(::So::Much::Trash::ResourceNamePatternRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -272,36 +272,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, multiparent_method_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      c = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.multiparent_method({ parent: parent }) do |response, operation|
+      c.multiparent_method({ parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.multiparent_method parent: parent do |response, operation|
+      c.multiparent_method parent: parent do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.multiparent_method ::So::Much::Trash::MultiparentRequest.new(parent: parent) do |response, operation|
+      c.multiparent_method ::So::Much::Trash::MultiparentRequest.new(parent: parent) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.multiparent_method({ parent: parent }, grpc_options) do |response, operation|
+      c.multiparent_method({ parent: parent }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.multiparent_method(::So::Much::Trash::MultiparentRequest.new(parent: parent), grpc_options) do |response, operation|
+      c.multiparent_method(::So::Much::Trash::MultiparentRequest.new(parent: parent), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -330,36 +330,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, no_arguments_multi_method_client_stub do
       # Create client
-      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      c = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.no_arguments_multi_method({ name: name }) do |response, operation|
+      c.no_arguments_multi_method({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.no_arguments_multi_method name: name do |response, operation|
+      c.no_arguments_multi_method name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.no_arguments_multi_method ::So::Much::Trash::NoArgumentsMultiRequest.new(name: name) do |response, operation|
+      c.no_arguments_multi_method ::So::Much::Trash::NoArgumentsMultiRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.no_arguments_multi_method({ name: name }, grpc_options) do |response, operation|
+      c.no_arguments_multi_method({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.no_arguments_multi_method(::So::Much::Trash::NoArgumentsMultiRequest.new(name: name), grpc_options) do |response, operation|
+      c.no_arguments_multi_method(::So::Much::Trash::NoArgumentsMultiRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
@@ -94,36 +94,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, simple_pattern_method_client_stub do
       # Create client
-      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
+      client_stub.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.simple_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
+      client_stub.simple_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.simple_pattern_method ::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
+      client_stub.simple_pattern_method ::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
+      client_stub.simple_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.simple_pattern_method(::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
+      client_stub.simple_pattern_method(::So::Much::Trash::SimplePatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -156,36 +156,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, complex_pattern_method_client_stub do
       # Create client
-      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
+      client_stub.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.complex_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
+      client_stub.complex_pattern_method real_name: real_name, ref: ref, repeated_ref: repeated_ref do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.complex_pattern_method ::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
+      client_stub.complex_pattern_method ::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
+      client_stub.complex_pattern_method({ real_name: real_name, ref: ref, repeated_ref: repeated_ref }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.complex_pattern_method(::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
+      client_stub.complex_pattern_method(::So::Much::Trash::ComplexPatternRequest.new(real_name: real_name, ref: ref, repeated_ref: repeated_ref), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -214,36 +214,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, resource_name_pattern_method_client_stub do
       # Create client
-      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.resource_name_pattern_method({ name: name }) do |response, operation|
+      client_stub.resource_name_pattern_method({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.resource_name_pattern_method name: name do |response, operation|
+      client_stub.resource_name_pattern_method name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.resource_name_pattern_method ::So::Much::Trash::ResourceNamePatternRequest.new(name: name) do |response, operation|
+      client_stub.resource_name_pattern_method ::So::Much::Trash::ResourceNamePatternRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.resource_name_pattern_method({ name: name }, grpc_options) do |response, operation|
+      client_stub.resource_name_pattern_method({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.resource_name_pattern_method(::So::Much::Trash::ResourceNamePatternRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.resource_name_pattern_method(::So::Much::Trash::ResourceNamePatternRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -272,36 +272,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, multiparent_method_client_stub do
       # Create client
-      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.multiparent_method({ parent: parent }) do |response, operation|
+      client_stub.multiparent_method({ parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.multiparent_method parent: parent do |response, operation|
+      client_stub.multiparent_method parent: parent do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.multiparent_method ::So::Much::Trash::MultiparentRequest.new(parent: parent) do |response, operation|
+      client_stub.multiparent_method ::So::Much::Trash::MultiparentRequest.new(parent: parent) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.multiparent_method({ parent: parent }, grpc_options) do |response, operation|
+      client_stub.multiparent_method({ parent: parent }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.multiparent_method(::So::Much::Trash::MultiparentRequest.new(parent: parent), grpc_options) do |response, operation|
+      client_stub.multiparent_method(::So::Much::Trash::MultiparentRequest.new(parent: parent), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -330,36 +330,36 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, no_arguments_multi_method_client_stub do
       # Create client
-      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+      client_stub = ::So::Much::Trash::ResourceNames::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.no_arguments_multi_method({ name: name }) do |response, operation|
+      client_stub.no_arguments_multi_method({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.no_arguments_multi_method name: name do |response, operation|
+      client_stub.no_arguments_multi_method name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.no_arguments_multi_method ::So::Much::Trash::NoArgumentsMultiRequest.new(name: name) do |response, operation|
+      client_stub.no_arguments_multi_method ::So::Much::Trash::NoArgumentsMultiRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.no_arguments_multi_method({ name: name }, grpc_options) do |response, operation|
+      client_stub.no_arguments_multi_method({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.no_arguments_multi_method(::So::Much::Trash::NoArgumentsMultiRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.no_arguments_multi_method(::So::Much::Trash::NoArgumentsMultiRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_rest_test.rb
@@ -114,32 +114,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -177,32 +177,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_info_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_info_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -240,32 +240,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_query_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_query_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -303,32 +303,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_simple_path_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_simple_path_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -366,32 +366,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_path_resource_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_path_resource_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -429,32 +429,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_path_trailing_resource_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_path_trailing_resource_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -492,32 +492,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_put_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_put_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -555,32 +555,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_patch_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_patch_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        c.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        c.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        c.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        c.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        c.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -609,32 +609,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_get_enum_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_enum_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_enum({ unknown_enum: unknown_enum }) do |_result, response|
+        c.get_enum({ unknown_enum: unknown_enum }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_enum unknown_enum: unknown_enum do |_result, response|
+        c.get_enum unknown_enum: unknown_enum do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |_result, response|
+        c.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_enum({ unknown_enum: unknown_enum }, call_options) do |_result, response|
+        c.get_enum({ unknown_enum: unknown_enum }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), call_options) do |_result, response|
+        c.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -664,32 +664,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_verify_enum_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, verify_enum_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.verify_enum({ request: request, continent: continent }) do |_result, response|
+        c.verify_enum({ request: request, continent: continent }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.verify_enum request: request, continent: continent do |_result, response|
+        c.verify_enum request: request, continent: continent do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |_result, response|
+        c.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.verify_enum({ request: request, continent: continent }, call_options) do |_result, response|
+        c.verify_enum({ request: request, continent: continent }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), call_options) do |_result, response|
+        c.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_rest_test.rb
@@ -114,32 +114,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -177,32 +177,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_info_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_info_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -240,32 +240,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_query_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_query_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -303,32 +303,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_simple_path_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_simple_path_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -366,32 +366,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_path_resource_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_path_resource_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -429,32 +429,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_path_trailing_resource_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_path_trailing_resource_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -492,32 +492,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_put_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_put_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -555,32 +555,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_repeat_data_body_patch_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, repeat_data_body_patch_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
+        client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
+        client_stub.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
+        client_stub.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
+        client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
+        client_stub.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -609,32 +609,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_get_enum_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_enum_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_enum({ unknown_enum: unknown_enum }) do |_result, response|
+        client_stub.get_enum({ unknown_enum: unknown_enum }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_enum unknown_enum: unknown_enum do |_result, response|
+        client_stub.get_enum unknown_enum: unknown_enum do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |_result, response|
+        client_stub.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_enum({ unknown_enum: unknown_enum }, call_options) do |_result, response|
+        client_stub.get_enum({ unknown_enum: unknown_enum }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), call_options) do |_result, response|
+        client_stub.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -664,32 +664,32 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Compliance::Rest::ServiceStub.stub :transcode_verify_enum_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, verify_enum_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Compliance::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.verify_enum({ request: request, continent: continent }) do |_result, response|
+        client_stub.verify_enum({ request: request, continent: continent }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.verify_enum request: request, continent: continent do |_result, response|
+        client_stub.verify_enum request: request, continent: continent do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |_result, response|
+        client_stub.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.verify_enum({ request: request, continent: continent }, call_options) do |_result, response|
+        client_stub.verify_enum({ request: request, continent: continent }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), call_options) do |_result, response|
+        client_stub.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
@@ -112,36 +112,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -192,36 +192,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_info_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -272,36 +272,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_query_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -352,36 +352,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_simple_path_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -432,36 +432,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_path_resource_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -512,36 +512,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_path_trailing_resource_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -592,36 +592,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_put_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -672,36 +672,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_patch_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      c.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      c.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      c.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      c.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      c.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -730,36 +730,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_enum_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_enum({ unknown_enum: unknown_enum }) do |response, operation|
+      c.get_enum({ unknown_enum: unknown_enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_enum unknown_enum: unknown_enum do |response, operation|
+      c.get_enum unknown_enum: unknown_enum do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |response, operation|
+      c.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_enum({ unknown_enum: unknown_enum }, grpc_options) do |response, operation|
+      c.get_enum({ unknown_enum: unknown_enum }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), grpc_options) do |response, operation|
+      c.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -790,36 +790,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, verify_enum_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.verify_enum({ request: request, continent: continent }) do |response, operation|
+      c.verify_enum({ request: request, continent: continent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.verify_enum request: request, continent: continent do |response, operation|
+      c.verify_enum request: request, continent: continent do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |response, operation|
+      c.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.verify_enum({ request: request, continent: continent }, grpc_options) do |response, operation|
+      c.verify_enum({ request: request, continent: continent }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), grpc_options) do |response, operation|
+      c.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
@@ -112,36 +112,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_body name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_body ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_body({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_body(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -192,36 +192,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_info_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_body_info name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_body_info ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_body_info({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_body_info(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -272,36 +272,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_query_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_query name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_query ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_query({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_query(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -352,36 +352,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_simple_path_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_simple_path name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_simple_path ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_simple_path({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_simple_path(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -432,36 +432,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_path_resource_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_path_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_path_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_path_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_path_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -512,36 +512,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_path_trailing_resource_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_path_trailing_resource name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_path_trailing_resource ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_path_trailing_resource({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_path_trailing_resource(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -592,36 +592,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_put_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_body_put name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_body_put ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_body_put({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_body_put(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -672,36 +672,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, repeat_data_body_patch_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
+      client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
+      client_stub.repeat_data_body_patch name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
+      client_stub.repeat_data_body_patch ::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
+      client_stub.repeat_data_body_patch({ name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
+      client_stub.repeat_data_body_patch(::Google::Showcase::V1beta1::RepeatRequest.new(name: name, info: info, server_verify: server_verify, intended_binding_uri: intended_binding_uri, f_int32: f_int32, f_int64: f_int64, f_double: f_double, p_int32: p_int32, p_int64: p_int64, p_double: p_double), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -730,36 +730,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_enum_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_enum({ unknown_enum: unknown_enum }) do |response, operation|
+      client_stub.get_enum({ unknown_enum: unknown_enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_enum unknown_enum: unknown_enum do |response, operation|
+      client_stub.get_enum unknown_enum: unknown_enum do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |response, operation|
+      client_stub.get_enum ::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_enum({ unknown_enum: unknown_enum }, grpc_options) do |response, operation|
+      client_stub.get_enum({ unknown_enum: unknown_enum }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), grpc_options) do |response, operation|
+      client_stub.get_enum(::Google::Showcase::V1beta1::EnumRequest.new(unknown_enum: unknown_enum), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -790,36 +790,36 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, verify_enum_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Compliance::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.verify_enum({ request: request, continent: continent }) do |response, operation|
+      client_stub.verify_enum({ request: request, continent: continent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.verify_enum request: request, continent: continent do |response, operation|
+      client_stub.verify_enum request: request, continent: continent do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |response, operation|
+      client_stub.verify_enum ::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.verify_enum({ request: request, continent: continent }, grpc_options) do |response, operation|
+      client_stub.verify_enum({ request: request, continent: continent }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), grpc_options) do |response, operation|
+      client_stub.verify_enum(::Google::Showcase::V1beta1::EnumResponse.new(request: request, continent: continent), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -99,40 +99,40 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -99,40 +99,40 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_rest_test.rb
@@ -110,32 +110,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_echo_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, echo_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |_result, response|
+        client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |_result, response|
+        client_stub.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |_result, response|
+        client_stub.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, call_options) do |_result, response|
+        client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), call_options) do |_result, response|
+        client_stub.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -165,32 +165,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_echo_error_details_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, echo_error_details_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |_result, response|
+        client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |_result, response|
+        client_stub.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |_result, response|
+        client_stub.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, call_options) do |_result, response|
+        client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), call_options) do |_result, response|
+        client_stub.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -219,32 +219,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_fail_echo_with_details_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, fail_echo_with_details_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.fail_echo_with_details({ message: message }) do |_result, response|
+        client_stub.fail_echo_with_details({ message: message }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.fail_echo_with_details message: message do |_result, response|
+        client_stub.fail_echo_with_details message: message do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |_result, response|
+        client_stub.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.fail_echo_with_details({ message: message }, call_options) do |_result, response|
+        client_stub.fail_echo_with_details({ message: message }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), call_options) do |_result, response|
+        client_stub.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -275,32 +275,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_expand_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, expand_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |_result, response|
+        client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use named arguments
-        client.expand content: content, error: error, stream_wait_time: stream_wait_time do |_result, response|
+        client_stub.expand content: content, error: error, stream_wait_time: stream_wait_time do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object
-        client.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |_result, response|
+        client_stub.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use hash object with options
-        client.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, call_options) do |_result, response|
+        client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object with options
-        client.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), call_options) do |_result, response|
+        client_stub.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
@@ -331,32 +331,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_paged_expand_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, paged_expand_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.paged_expand content: content, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.paged_expand content: content, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.paged_expand({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -387,32 +387,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_paged_expand_legacy_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, paged_expand_legacy_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |_result, response|
+        client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |_result, response|
+        client_stub.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |_result, response|
+        client_stub.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, call_options) do |_result, response|
+        client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), call_options) do |_result, response|
+        client_stub.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -443,32 +443,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_paged_expand_legacy_mapped_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, paged_expand_legacy_mapped_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -498,32 +498,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_wait_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, wait_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.wait({ end_time: end_time, error: error }) do |_result, response|
+        client_stub.wait({ end_time: end_time, error: error }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.wait end_time: end_time, error: error do |_result, response|
+        client_stub.wait end_time: end_time, error: error do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |_result, response|
+        client_stub.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.wait({ end_time: end_time, error: error }, call_options) do |_result, response|
+        client_stub.wait({ end_time: end_time, error: error }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), call_options) do |_result, response|
+        client_stub.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -553,32 +553,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_block_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, block_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.block({ response_delay: response_delay, error: error }) do |_result, response|
+        client_stub.block({ response_delay: response_delay, error: error }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.block response_delay: response_delay, error: error do |_result, response|
+        client_stub.block response_delay: response_delay, error: error do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |_result, response|
+        client_stub.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.block({ response_delay: response_delay, error: error }, call_options) do |_result, response|
+        client_stub.block({ response_delay: response_delay, error: error }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), call_options) do |_result, response|
+        client_stub.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_rest_test.rb
@@ -110,32 +110,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_echo_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, echo_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |_result, response|
+        c.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |_result, response|
+        c.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |_result, response|
+        c.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, call_options) do |_result, response|
+        c.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), call_options) do |_result, response|
+        c.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -165,32 +165,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_echo_error_details_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, echo_error_details_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |_result, response|
+        c.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |_result, response|
+        c.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |_result, response|
+        c.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, call_options) do |_result, response|
+        c.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), call_options) do |_result, response|
+        c.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -219,32 +219,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_fail_echo_with_details_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, fail_echo_with_details_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.fail_echo_with_details({ message: message }) do |_result, response|
+        c.fail_echo_with_details({ message: message }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.fail_echo_with_details message: message do |_result, response|
+        c.fail_echo_with_details message: message do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |_result, response|
+        c.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.fail_echo_with_details({ message: message }, call_options) do |_result, response|
+        c.fail_echo_with_details({ message: message }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), call_options) do |_result, response|
+        c.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -275,32 +275,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_expand_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, expand_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |_result, response|
+        c.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use named arguments
-        client_stub.expand content: content, error: error, stream_wait_time: stream_wait_time do |_result, response|
+        c.expand content: content, error: error, stream_wait_time: stream_wait_time do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object
-        client_stub.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |_result, response|
+        c.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use hash object with options
-        client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, call_options) do |_result, response|
+        c.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object with options
-        client_stub.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), call_options) do |_result, response|
+        c.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
@@ -331,32 +331,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_paged_expand_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, paged_expand_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.paged_expand content: content, page_size: page_size, page_token: page_token do |_result, response|
+        c.paged_expand content: content, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
+        c.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.paged_expand({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -387,32 +387,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_paged_expand_legacy_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, paged_expand_legacy_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |_result, response|
+        c.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |_result, response|
+        c.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |_result, response|
+        c.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, call_options) do |_result, response|
+        c.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), call_options) do |_result, response|
+        c.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -443,32 +443,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_paged_expand_legacy_mapped_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, paged_expand_legacy_mapped_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |_result, response|
+        c.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
+        c.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -498,32 +498,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_wait_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, wait_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.wait({ end_time: end_time, error: error }) do |_result, response|
+        c.wait({ end_time: end_time, error: error }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.wait end_time: end_time, error: error do |_result, response|
+        c.wait end_time: end_time, error: error do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |_result, response|
+        c.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.wait({ end_time: end_time, error: error }, call_options) do |_result, response|
+        c.wait({ end_time: end_time, error: error }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), call_options) do |_result, response|
+        c.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -553,32 +553,32 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Echo::Rest::ServiceStub.stub :transcode_block_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, block_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Echo::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.block({ response_delay: response_delay, error: error }) do |_result, response|
+        c.block({ response_delay: response_delay, error: error }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.block response_delay: response_delay, error: error do |_result, response|
+        c.block response_delay: response_delay, error: error do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |_result, response|
+        c.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.block({ response_delay: response_delay, error: error }, call_options) do |_result, response|
+        c.block({ response_delay: response_delay, error: error }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), call_options) do |_result, response|
+        c.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -102,36 +102,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, echo_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |response, operation|
+      c.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |response, operation|
+      c.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |response, operation|
+      c.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, grpc_options) do |response, operation|
+      c.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), grpc_options) do |response, operation|
+      c.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -162,36 +162,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, echo_error_details_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |response, operation|
+      c.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |response, operation|
+      c.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |response, operation|
+      c.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, grpc_options) do |response, operation|
+      c.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), grpc_options) do |response, operation|
+      c.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -220,36 +220,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, fail_echo_with_details_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.fail_echo_with_details({ message: message }) do |response, operation|
+      c.fail_echo_with_details({ message: message }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.fail_echo_with_details message: message do |response, operation|
+      c.fail_echo_with_details message: message do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |response, operation|
+      c.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.fail_echo_with_details({ message: message }, grpc_options) do |response, operation|
+      c.fail_echo_with_details({ message: message }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), grpc_options) do |response, operation|
+      c.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -282,12 +282,12 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, expand_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |response, operation|
+      c.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -296,7 +296,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client_stub.expand content: content, error: error, stream_wait_time: stream_wait_time do |response, operation|
+      c.expand content: content, error: error, stream_wait_time: stream_wait_time do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -305,7 +305,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client_stub.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |response, operation|
+      c.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -314,7 +314,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, grpc_options) do |response, operation|
+      c.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -323,7 +323,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client_stub.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), grpc_options) do |response, operation|
+      c.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -360,7 +360,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, collect_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -368,7 +368,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.collect enum_input do |response, operation|
+      c.collect enum_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -377,7 +377,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client_stub.collect stream_input do |response, operation|
+      c.collect stream_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -389,7 +389,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.collect enum_input, grpc_options do |response, operation|
+      c.collect enum_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -398,7 +398,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client_stub.collect stream_input, grpc_options do |response, operation|
+      c.collect stream_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -448,7 +448,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, chat_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -456,7 +456,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.chat enum_input do |response, operation|
+      c.chat enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -468,7 +468,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client_stub.chat stream_input do |response, operation|
+      c.chat stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -483,7 +483,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.chat enum_input, grpc_options do |response, operation|
+      c.chat enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -495,7 +495,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client_stub.chat stream_input, grpc_options do |response, operation|
+      c.chat stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -547,40 +547,40 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, paged_expand_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.paged_expand content: content, page_size: page_size, page_token: page_token do |response, operation|
+      c.paged_expand content: content, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
+      c.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.paged_expand({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -614,36 +614,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, paged_expand_legacy_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |response, operation|
+      c.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |response, operation|
+      c.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |response, operation|
+      c.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, grpc_options) do |response, operation|
+      c.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), grpc_options) do |response, operation|
+      c.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -676,40 +676,40 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, paged_expand_legacy_mapped_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |response, operation|
+      c.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
+      c.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -743,40 +743,40 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait({ end_time: end_time, error: error }) do |response, operation|
+      c.wait({ end_time: end_time, error: error }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait end_time: end_time, error: error do |response, operation|
+      c.wait end_time: end_time, error: error do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |response, operation|
+      c.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait({ end_time: end_time, error: error }, grpc_options) do |response, operation|
+      c.wait({ end_time: end_time, error: error }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), grpc_options) do |response, operation|
+      c.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -809,36 +809,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, block_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.block({ response_delay: response_delay, error: error }) do |response, operation|
+      c.block({ response_delay: response_delay, error: error }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.block response_delay: response_delay, error: error do |response, operation|
+      c.block response_delay: response_delay, error: error do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |response, operation|
+      c.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.block({ response_delay: response_delay, error: error }, grpc_options) do |response, operation|
+      c.block({ response_delay: response_delay, error: error }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), grpc_options) do |response, operation|
+      c.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -102,36 +102,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, echo_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |response, operation|
+      client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |response, operation|
+      client_stub.echo content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |response, operation|
+      client_stub.echo ::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, grpc_options) do |response, operation|
+      client_stub.echo({ content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), grpc_options) do |response, operation|
+      client_stub.echo(::Google::Showcase::V1beta1::EchoRequest.new(content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -162,36 +162,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, echo_error_details_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |response, operation|
+      client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |response, operation|
+      client_stub.echo_error_details single_detail_text: single_detail_text, multi_detail_text: multi_detail_text do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |response, operation|
+      client_stub.echo_error_details ::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, grpc_options) do |response, operation|
+      client_stub.echo_error_details({ single_detail_text: single_detail_text, multi_detail_text: multi_detail_text }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), grpc_options) do |response, operation|
+      client_stub.echo_error_details(::Google::Showcase::V1beta1::EchoErrorDetailsRequest.new(single_detail_text: single_detail_text, multi_detail_text: multi_detail_text), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -220,36 +220,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, fail_echo_with_details_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.fail_echo_with_details({ message: message }) do |response, operation|
+      client_stub.fail_echo_with_details({ message: message }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.fail_echo_with_details message: message do |response, operation|
+      client_stub.fail_echo_with_details message: message do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |response, operation|
+      client_stub.fail_echo_with_details ::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.fail_echo_with_details({ message: message }, grpc_options) do |response, operation|
+      client_stub.fail_echo_with_details({ message: message }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), grpc_options) do |response, operation|
+      client_stub.fail_echo_with_details(::Google::Showcase::V1beta1::FailEchoWithDetailsRequest.new(message: message), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -282,12 +282,12 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, expand_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |response, operation|
+      client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -296,7 +296,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client.expand content: content, error: error, stream_wait_time: stream_wait_time do |response, operation|
+      client_stub.expand content: content, error: error, stream_wait_time: stream_wait_time do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -305,7 +305,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |response, operation|
+      client_stub.expand ::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -314,7 +314,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, grpc_options) do |response, operation|
+      client_stub.expand({ content: content, error: error, stream_wait_time: stream_wait_time }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -323,7 +323,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), grpc_options) do |response, operation|
+      client_stub.expand(::Google::Showcase::V1beta1::ExpandRequest.new(content: content, error: error, stream_wait_time: stream_wait_time), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -360,7 +360,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, collect_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -368,7 +368,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client.collect enum_input do |response, operation|
+      client_stub.collect enum_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -377,7 +377,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client.collect stream_input do |response, operation|
+      client_stub.collect stream_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -389,7 +389,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client.collect enum_input, grpc_options do |response, operation|
+      client_stub.collect enum_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -398,7 +398,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client.collect stream_input, grpc_options do |response, operation|
+      client_stub.collect stream_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -448,7 +448,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, chat_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -456,7 +456,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client.chat enum_input do |response, operation|
+      client_stub.chat enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -468,7 +468,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client.chat stream_input do |response, operation|
+      client_stub.chat stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -483,7 +483,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       enum_input = [request_hash, request_proto].to_enum
-      client.chat enum_input, grpc_options do |response, operation|
+      client_stub.chat enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -495,7 +495,7 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       request_hash = { content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id }
       request_proto = ::Google::Showcase::V1beta1::EchoRequest.new content: content, severity: severity, header: header, other_header: other_header, request_id: request_id, other_request_id: other_request_id
       stream_input = Gapic::StreamInput.new
-      client.chat stream_input, grpc_options do |response, operation|
+      client_stub.chat stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::EchoResponse, r
@@ -547,40 +547,40 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, paged_expand_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.paged_expand content: content, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.paged_expand content: content, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.paged_expand ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.paged_expand({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.paged_expand({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.paged_expand(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -614,36 +614,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, paged_expand_legacy_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |response, operation|
+      client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |response, operation|
+      client_stub.paged_expand_legacy content: content, max_results: max_results, page_token: page_token do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |response, operation|
+      client_stub.paged_expand_legacy ::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.paged_expand_legacy({ content: content, max_results: max_results, page_token: page_token }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.paged_expand_legacy(::Google::Showcase::V1beta1::PagedExpandLegacyRequest.new(content: content, max_results: max_results, page_token: page_token), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -676,40 +676,40 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, paged_expand_legacy_mapped_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.paged_expand_legacy_mapped content: content, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.paged_expand_legacy_mapped ::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.paged_expand_legacy_mapped({ content: content, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.paged_expand_legacy_mapped(::Google::Showcase::V1beta1::PagedExpandRequest.new(content: content, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -743,40 +743,40 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait({ end_time: end_time, error: error }) do |response, operation|
+      client_stub.wait({ end_time: end_time, error: error }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait end_time: end_time, error: error do |response, operation|
+      client_stub.wait end_time: end_time, error: error do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |response, operation|
+      client_stub.wait ::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait({ end_time: end_time, error: error }, grpc_options) do |response, operation|
+      client_stub.wait({ end_time: end_time, error: error }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), grpc_options) do |response, operation|
+      client_stub.wait(::Google::Showcase::V1beta1::WaitRequest.new(end_time: end_time, error: error), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -809,36 +809,36 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, block_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.block({ response_delay: response_delay, error: error }) do |response, operation|
+      client_stub.block({ response_delay: response_delay, error: error }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.block response_delay: response_delay, error: error do |response, operation|
+      client_stub.block response_delay: response_delay, error: error do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |response, operation|
+      client_stub.block ::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.block({ response_delay: response_delay, error: error }, grpc_options) do |response, operation|
+      client_stub.block({ response_delay: response_delay, error: error }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), grpc_options) do |response, operation|
+      client_stub.block(::Google::Showcase::V1beta1::BlockRequest.new(response_delay: response_delay, error: error), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_create_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_user_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_user({ user: user }) do |_result, response|
+        c.create_user({ user: user }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_user user: user do |_result, response|
+        c.create_user user: user do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |_result, response|
+        c.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_user({ user: user }, call_options) do |_result, response|
+        c.create_user({ user: user }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), call_options) do |_result, response|
+        c.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_get_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_user_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_user({ name: name }) do |_result, response|
+        c.get_user({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_user name: name do |_result, response|
+        c.get_user name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |_result, response|
+        c.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_user({ name: name }, call_options) do |_result, response|
+        c.get_user({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), call_options) do |_result, response|
+        c.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -214,32 +214,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_update_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_user_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.update_user({ user: user, update_mask: update_mask }) do |_result, response|
+        c.update_user({ user: user, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.update_user user: user, update_mask: update_mask do |_result, response|
+        c.update_user user: user, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |_result, response|
+        c.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.update_user({ user: user, update_mask: update_mask }, call_options) do |_result, response|
+        c.update_user({ user: user, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), call_options) do |_result, response|
+        c.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_delete_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_user_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_user({ name: name }) do |_result, response|
+        c.delete_user({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_user name: name do |_result, response|
+        c.delete_user name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |_result, response|
+        c.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_user({ name: name }, call_options) do |_result, response|
+        c.delete_user({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), call_options) do |_result, response|
+        c.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -323,32 +323,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_list_users_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_users_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_users({ page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_users({ page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_users page_size: page_size, page_token: page_token do |_result, response|
+        c.list_users page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_users({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_users({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_create_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_user_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_user({ user: user }) do |_result, response|
+        client_stub.create_user({ user: user }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_user user: user do |_result, response|
+        client_stub.create_user user: user do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |_result, response|
+        client_stub.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_user({ user: user }, call_options) do |_result, response|
+        client_stub.create_user({ user: user }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), call_options) do |_result, response|
+        client_stub.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_get_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_user_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_user({ name: name }) do |_result, response|
+        client_stub.get_user({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_user name: name do |_result, response|
+        client_stub.get_user name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |_result, response|
+        client_stub.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_user({ name: name }, call_options) do |_result, response|
+        client_stub.get_user({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -214,32 +214,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_update_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_user_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.update_user({ user: user, update_mask: update_mask }) do |_result, response|
+        client_stub.update_user({ user: user, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.update_user user: user, update_mask: update_mask do |_result, response|
+        client_stub.update_user user: user, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |_result, response|
+        client_stub.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.update_user({ user: user, update_mask: update_mask }, call_options) do |_result, response|
+        client_stub.update_user({ user: user, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), call_options) do |_result, response|
+        client_stub.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_delete_user_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_user_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_user({ name: name }) do |_result, response|
+        client_stub.delete_user({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_user name: name do |_result, response|
+        client_stub.delete_user name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |_result, response|
+        client_stub.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_user({ name: name }, call_options) do |_result, response|
+        client_stub.delete_user({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -323,32 +323,32 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Identity::Rest::ServiceStub.stub :transcode_list_users_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_users_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Identity::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_users({ page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_users({ page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_users page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_users page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_users({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_users({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_user_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_user({ user: user }) do |response, operation|
+      client_stub.create_user({ user: user }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_user user: user do |response, operation|
+      client_stub.create_user user: user do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |response, operation|
+      client_stub.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_user({ user: user }, grpc_options) do |response, operation|
+      client_stub.create_user({ user: user }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), grpc_options) do |response, operation|
+      client_stub.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_user_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_user({ name: name }) do |response, operation|
+      client_stub.get_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_user name: name do |response, operation|
+      client_stub.get_user name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |response, operation|
+      client_stub.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_user({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_user({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -208,36 +208,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_user_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_user({ user: user, update_mask: update_mask }) do |response, operation|
+      client_stub.update_user({ user: user, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_user user: user, update_mask: update_mask do |response, operation|
+      client_stub.update_user user: user, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |response, operation|
+      client_stub.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_user({ user: user, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_user({ user: user, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -266,36 +266,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_user_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_user({ name: name }) do |response, operation|
+      client_stub.delete_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_user name: name do |response, operation|
+      client_stub.delete_user name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |response, operation|
+      client_stub.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_user({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_user({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -326,40 +326,40 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_users_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_users({ page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_users({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_users page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_users page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_users({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_users({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_user_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_user({ user: user }) do |response, operation|
+      c.create_user({ user: user }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_user user: user do |response, operation|
+      c.create_user user: user do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |response, operation|
+      c.create_user ::Google::Showcase::V1beta1::CreateUserRequest.new(user: user) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_user({ user: user }, grpc_options) do |response, operation|
+      c.create_user({ user: user }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), grpc_options) do |response, operation|
+      c.create_user(::Google::Showcase::V1beta1::CreateUserRequest.new(user: user), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_user_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_user({ name: name }) do |response, operation|
+      c.get_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_user name: name do |response, operation|
+      c.get_user name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |response, operation|
+      c.get_user ::Google::Showcase::V1beta1::GetUserRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_user({ name: name }, grpc_options) do |response, operation|
+      c.get_user({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_user(::Google::Showcase::V1beta1::GetUserRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -208,36 +208,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_user_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_user({ user: user, update_mask: update_mask }) do |response, operation|
+      c.update_user({ user: user, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_user user: user, update_mask: update_mask do |response, operation|
+      c.update_user user: user, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |response, operation|
+      c.update_user ::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_user({ user: user, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_user({ user: user, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_user(::Google::Showcase::V1beta1::UpdateUserRequest.new(user: user, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -266,36 +266,36 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_user_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_user({ name: name }) do |response, operation|
+      c.delete_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_user name: name do |response, operation|
+      c.delete_user name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |response, operation|
+      c.delete_user ::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_user({ name: name }, grpc_options) do |response, operation|
+      c.delete_user({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_user(::Google::Showcase::V1beta1::DeleteUserRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -326,40 +326,40 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_users_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_users({ page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_users({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_users page_size: page_size, page_token: page_token do |response, operation|
+      c.list_users page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_users ::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_users({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_users({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_users(::Google::Showcase::V1beta1::ListUsersRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -99,40 +99,40 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -99,40 +99,40 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_create_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_room_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_room({ room: room }) do |_result, response|
+        client_stub.create_room({ room: room }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_room room: room do |_result, response|
+        client_stub.create_room room: room do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |_result, response|
+        client_stub.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_room({ room: room }, call_options) do |_result, response|
+        client_stub.create_room({ room: room }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), call_options) do |_result, response|
+        client_stub.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_get_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_room_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_room({ name: name }) do |_result, response|
+        client_stub.get_room({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_room name: name do |_result, response|
+        client_stub.get_room name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |_result, response|
+        client_stub.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_room({ name: name }, call_options) do |_result, response|
+        client_stub.get_room({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -214,32 +214,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_update_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_room_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.update_room({ room: room, update_mask: update_mask }) do |_result, response|
+        client_stub.update_room({ room: room, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.update_room room: room, update_mask: update_mask do |_result, response|
+        client_stub.update_room room: room, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |_result, response|
+        client_stub.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.update_room({ room: room, update_mask: update_mask }, call_options) do |_result, response|
+        client_stub.update_room({ room: room, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), call_options) do |_result, response|
+        client_stub.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_delete_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_room_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_room({ name: name }) do |_result, response|
+        client_stub.delete_room({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_room name: name do |_result, response|
+        client_stub.delete_room name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |_result, response|
+        client_stub.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_room({ name: name }, call_options) do |_result, response|
+        client_stub.delete_room({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -323,32 +323,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_list_rooms_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_rooms_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_rooms({ page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_rooms({ page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_rooms page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_rooms page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_rooms({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_rooms({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -378,32 +378,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_create_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_blurb_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_blurb({ parent: parent, blurb: blurb }) do |_result, response|
+        client_stub.create_blurb({ parent: parent, blurb: blurb }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_blurb parent: parent, blurb: blurb do |_result, response|
+        client_stub.create_blurb parent: parent, blurb: blurb do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |_result, response|
+        client_stub.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_blurb({ parent: parent, blurb: blurb }, call_options) do |_result, response|
+        client_stub.create_blurb({ parent: parent, blurb: blurb }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), call_options) do |_result, response|
+        client_stub.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -432,32 +432,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_get_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_blurb_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_blurb({ name: name }) do |_result, response|
+        client_stub.get_blurb({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_blurb name: name do |_result, response|
+        client_stub.get_blurb name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |_result, response|
+        client_stub.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_blurb({ name: name }, call_options) do |_result, response|
+        client_stub.get_blurb({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -487,32 +487,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_update_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_blurb_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.update_blurb({ blurb: blurb, update_mask: update_mask }) do |_result, response|
+        client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.update_blurb blurb: blurb, update_mask: update_mask do |_result, response|
+        client_stub.update_blurb blurb: blurb, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |_result, response|
+        client_stub.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.update_blurb({ blurb: blurb, update_mask: update_mask }, call_options) do |_result, response|
+        client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), call_options) do |_result, response|
+        client_stub.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -541,32 +541,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_delete_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_blurb_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_blurb({ name: name }) do |_result, response|
+        client_stub.delete_blurb({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_blurb name: name do |_result, response|
+        client_stub.delete_blurb name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |_result, response|
+        client_stub.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_blurb({ name: name }, call_options) do |_result, response|
+        client_stub.delete_blurb({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -597,32 +597,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_list_blurbs_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_blurbs_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -654,32 +654,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_search_blurbs_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, search_blurbs_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -709,32 +709,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_stream_blurbs_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, stream_blurbs_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.stream_blurbs({ name: name, expire_time: expire_time }) do |_result, response|
+        client_stub.stream_blurbs({ name: name, expire_time: expire_time }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use named arguments
-        client.stream_blurbs name: name, expire_time: expire_time do |_result, response|
+        client_stub.stream_blurbs name: name, expire_time: expire_time do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object
-        client.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |_result, response|
+        client_stub.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use hash object with options
-        client.stream_blurbs({ name: name, expire_time: expire_time }, call_options) do |_result, response|
+        client_stub.stream_blurbs({ name: name, expire_time: expire_time }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object with options
-        client.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), call_options) do |_result, response|
+        client_stub.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_create_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_room_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_room({ room: room }) do |_result, response|
+        c.create_room({ room: room }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_room room: room do |_result, response|
+        c.create_room room: room do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |_result, response|
+        c.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_room({ room: room }, call_options) do |_result, response|
+        c.create_room({ room: room }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), call_options) do |_result, response|
+        c.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_get_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_room_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_room({ name: name }) do |_result, response|
+        c.get_room({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_room name: name do |_result, response|
+        c.get_room name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |_result, response|
+        c.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_room({ name: name }, call_options) do |_result, response|
+        c.get_room({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), call_options) do |_result, response|
+        c.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -214,32 +214,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_update_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_room_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.update_room({ room: room, update_mask: update_mask }) do |_result, response|
+        c.update_room({ room: room, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.update_room room: room, update_mask: update_mask do |_result, response|
+        c.update_room room: room, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |_result, response|
+        c.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.update_room({ room: room, update_mask: update_mask }, call_options) do |_result, response|
+        c.update_room({ room: room, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), call_options) do |_result, response|
+        c.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_delete_room_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_room_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_room({ name: name }) do |_result, response|
+        c.delete_room({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_room name: name do |_result, response|
+        c.delete_room name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |_result, response|
+        c.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_room({ name: name }, call_options) do |_result, response|
+        c.delete_room({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), call_options) do |_result, response|
+        c.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -323,32 +323,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_list_rooms_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_rooms_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_rooms({ page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_rooms({ page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_rooms page_size: page_size, page_token: page_token do |_result, response|
+        c.list_rooms page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_rooms({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_rooms({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -378,32 +378,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_create_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_blurb_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_blurb({ parent: parent, blurb: blurb }) do |_result, response|
+        c.create_blurb({ parent: parent, blurb: blurb }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_blurb parent: parent, blurb: blurb do |_result, response|
+        c.create_blurb parent: parent, blurb: blurb do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |_result, response|
+        c.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_blurb({ parent: parent, blurb: blurb }, call_options) do |_result, response|
+        c.create_blurb({ parent: parent, blurb: blurb }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), call_options) do |_result, response|
+        c.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -432,32 +432,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_get_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_blurb_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_blurb({ name: name }) do |_result, response|
+        c.get_blurb({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_blurb name: name do |_result, response|
+        c.get_blurb name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |_result, response|
+        c.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_blurb({ name: name }, call_options) do |_result, response|
+        c.get_blurb({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), call_options) do |_result, response|
+        c.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -487,32 +487,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_update_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_blurb_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }) do |_result, response|
+        c.update_blurb({ blurb: blurb, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.update_blurb blurb: blurb, update_mask: update_mask do |_result, response|
+        c.update_blurb blurb: blurb, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |_result, response|
+        c.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }, call_options) do |_result, response|
+        c.update_blurb({ blurb: blurb, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), call_options) do |_result, response|
+        c.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -541,32 +541,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_delete_blurb_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_blurb_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_blurb({ name: name }) do |_result, response|
+        c.delete_blurb({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_blurb name: name do |_result, response|
+        c.delete_blurb name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |_result, response|
+        c.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_blurb({ name: name }, call_options) do |_result, response|
+        c.delete_blurb({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), call_options) do |_result, response|
+        c.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -597,32 +597,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_list_blurbs_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_blurbs_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -654,32 +654,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_search_blurbs_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, search_blurbs_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -709,32 +709,32 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Messaging::Rest::ServiceStub.stub :transcode_stream_blurbs_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, stream_blurbs_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Messaging::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.stream_blurbs({ name: name, expire_time: expire_time }) do |_result, response|
+        c.stream_blurbs({ name: name, expire_time: expire_time }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use named arguments
-        client_stub.stream_blurbs name: name, expire_time: expire_time do |_result, response|
+        c.stream_blurbs name: name, expire_time: expire_time do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object
-        client_stub.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |_result, response|
+        c.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use hash object with options
-        client_stub.stream_blurbs({ name: name, expire_time: expire_time }, call_options) do |_result, response|
+        c.stream_blurbs({ name: name, expire_time: expire_time }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object with options
-        client_stub.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), call_options) do |_result, response|
+        c.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_room_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_room({ room: room }) do |response, operation|
+      c.create_room({ room: room }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_room room: room do |response, operation|
+      c.create_room room: room do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |response, operation|
+      c.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_room({ room: room }, grpc_options) do |response, operation|
+      c.create_room({ room: room }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), grpc_options) do |response, operation|
+      c.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_room_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_room({ name: name }) do |response, operation|
+      c.get_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_room name: name do |response, operation|
+      c.get_room name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |response, operation|
+      c.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_room({ name: name }, grpc_options) do |response, operation|
+      c.get_room({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -208,36 +208,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_room_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_room({ room: room, update_mask: update_mask }) do |response, operation|
+      c.update_room({ room: room, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_room room: room, update_mask: update_mask do |response, operation|
+      c.update_room room: room, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |response, operation|
+      c.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_room({ room: room, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_room({ room: room, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -266,36 +266,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_room_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_room({ name: name }) do |response, operation|
+      c.delete_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_room name: name do |response, operation|
+      c.delete_room name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |response, operation|
+      c.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_room({ name: name }, grpc_options) do |response, operation|
+      c.delete_room({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -326,40 +326,40 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_rooms_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_rooms({ page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_rooms({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_rooms page_size: page_size, page_token: page_token do |response, operation|
+      c.list_rooms page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_rooms({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_rooms({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -391,36 +391,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_blurb_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_blurb({ parent: parent, blurb: blurb }) do |response, operation|
+      c.create_blurb({ parent: parent, blurb: blurb }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_blurb parent: parent, blurb: blurb do |response, operation|
+      c.create_blurb parent: parent, blurb: blurb do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |response, operation|
+      c.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_blurb({ parent: parent, blurb: blurb }, grpc_options) do |response, operation|
+      c.create_blurb({ parent: parent, blurb: blurb }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), grpc_options) do |response, operation|
+      c.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -449,36 +449,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_blurb_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_blurb({ name: name }) do |response, operation|
+      c.get_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_blurb name: name do |response, operation|
+      c.get_blurb name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |response, operation|
+      c.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_blurb({ name: name }, grpc_options) do |response, operation|
+      c.get_blurb({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -509,36 +509,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_blurb_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }) do |response, operation|
+      c.update_blurb({ blurb: blurb, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.update_blurb blurb: blurb, update_mask: update_mask do |response, operation|
+      c.update_blurb blurb: blurb, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |response, operation|
+      c.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_blurb({ blurb: blurb, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -567,36 +567,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_blurb_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_blurb({ name: name }) do |response, operation|
+      c.delete_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_blurb name: name do |response, operation|
+      c.delete_blurb name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |response, operation|
+      c.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_blurb({ name: name }, grpc_options) do |response, operation|
+      c.delete_blurb({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -629,40 +629,40 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_blurbs_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -698,40 +698,40 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, search_blurbs_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -763,12 +763,12 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, stream_blurbs_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.stream_blurbs({ name: name, expire_time: expire_time }) do |response, operation|
+      c.stream_blurbs({ name: name, expire_time: expire_time }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -777,7 +777,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client_stub.stream_blurbs name: name, expire_time: expire_time do |response, operation|
+      c.stream_blurbs name: name, expire_time: expire_time do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -786,7 +786,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client_stub.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |response, operation|
+      c.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -795,7 +795,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client_stub.stream_blurbs({ name: name, expire_time: expire_time }, grpc_options) do |response, operation|
+      c.stream_blurbs({ name: name, expire_time: expire_time }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -804,7 +804,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client_stub.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), grpc_options) do |response, operation|
+      c.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -837,7 +837,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, send_blurbs_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -845,7 +845,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.send_blurbs enum_input do |response, operation|
+      c.send_blurbs enum_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -854,7 +854,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       stream_input = Gapic::StreamInput.new
-      client_stub.send_blurbs stream_input do |response, operation|
+      c.send_blurbs stream_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -866,7 +866,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.send_blurbs enum_input, grpc_options do |response, operation|
+      c.send_blurbs enum_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -875,7 +875,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       stream_input = Gapic::StreamInput.new
-      client_stub.send_blurbs stream_input, grpc_options do |response, operation|
+      c.send_blurbs stream_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -914,7 +914,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, connect_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -922,7 +922,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.connect enum_input do |response, operation|
+      c.connect enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -934,7 +934,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       stream_input = Gapic::StreamInput.new
-      client_stub.connect stream_input do |response, operation|
+      c.connect stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -949,7 +949,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       enum_input = [request_hash, request_proto].to_enum
-      client_stub.connect enum_input, grpc_options do |response, operation|
+      c.connect enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -961,7 +961,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       stream_input = Gapic::StreamInput.new
-      client_stub.connect stream_input, grpc_options do |response, operation|
+      c.connect stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_room_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_room({ room: room }) do |response, operation|
+      client_stub.create_room({ room: room }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_room room: room do |response, operation|
+      client_stub.create_room room: room do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |response, operation|
+      client_stub.create_room ::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_room({ room: room }, grpc_options) do |response, operation|
+      client_stub.create_room({ room: room }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), grpc_options) do |response, operation|
+      client_stub.create_room(::Google::Showcase::V1beta1::CreateRoomRequest.new(room: room), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_room_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_room({ name: name }) do |response, operation|
+      client_stub.get_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_room name: name do |response, operation|
+      client_stub.get_room name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |response, operation|
+      client_stub.get_room ::Google::Showcase::V1beta1::GetRoomRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_room({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_room({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_room(::Google::Showcase::V1beta1::GetRoomRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -208,36 +208,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_room_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_room({ room: room, update_mask: update_mask }) do |response, operation|
+      client_stub.update_room({ room: room, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_room room: room, update_mask: update_mask do |response, operation|
+      client_stub.update_room room: room, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |response, operation|
+      client_stub.update_room ::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_room({ room: room, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_room({ room: room, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_room(::Google::Showcase::V1beta1::UpdateRoomRequest.new(room: room, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -266,36 +266,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_room_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_room({ name: name }) do |response, operation|
+      client_stub.delete_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_room name: name do |response, operation|
+      client_stub.delete_room name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |response, operation|
+      client_stub.delete_room ::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_room({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_room({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_room(::Google::Showcase::V1beta1::DeleteRoomRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -326,40 +326,40 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_rooms_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_rooms({ page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_rooms({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_rooms page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_rooms page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_rooms ::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_rooms({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_rooms({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_rooms(::Google::Showcase::V1beta1::ListRoomsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -391,36 +391,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_blurb_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_blurb({ parent: parent, blurb: blurb }) do |response, operation|
+      client_stub.create_blurb({ parent: parent, blurb: blurb }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_blurb parent: parent, blurb: blurb do |response, operation|
+      client_stub.create_blurb parent: parent, blurb: blurb do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |response, operation|
+      client_stub.create_blurb ::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_blurb({ parent: parent, blurb: blurb }, grpc_options) do |response, operation|
+      client_stub.create_blurb({ parent: parent, blurb: blurb }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), grpc_options) do |response, operation|
+      client_stub.create_blurb(::Google::Showcase::V1beta1::CreateBlurbRequest.new(parent: parent, blurb: blurb), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -449,36 +449,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_blurb_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_blurb({ name: name }) do |response, operation|
+      client_stub.get_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_blurb name: name do |response, operation|
+      client_stub.get_blurb name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |response, operation|
+      client_stub.get_blurb ::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_blurb({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_blurb({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_blurb(::Google::Showcase::V1beta1::GetBlurbRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -509,36 +509,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_blurb_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_blurb({ blurb: blurb, update_mask: update_mask }) do |response, operation|
+      client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_blurb blurb: blurb, update_mask: update_mask do |response, operation|
+      client_stub.update_blurb blurb: blurb, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |response, operation|
+      client_stub.update_blurb ::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_blurb({ blurb: blurb, update_mask: update_mask }, grpc_options) do |response, operation|
+      client_stub.update_blurb({ blurb: blurb, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), grpc_options) do |response, operation|
+      client_stub.update_blurb(::Google::Showcase::V1beta1::UpdateBlurbRequest.new(blurb: blurb, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -567,36 +567,36 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_blurb_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_blurb({ name: name }) do |response, operation|
+      client_stub.delete_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_blurb name: name do |response, operation|
+      client_stub.delete_blurb name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |response, operation|
+      client_stub.delete_blurb ::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_blurb({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_blurb({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_blurb(::Google::Showcase::V1beta1::DeleteBlurbRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -629,40 +629,40 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_blurbs_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_blurbs ::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_blurbs(::Google::Showcase::V1beta1::ListBlurbsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -698,40 +698,40 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, search_blurbs_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.search_blurbs ::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.search_blurbs(::Google::Showcase::V1beta1::SearchBlurbsRequest.new(query: query, parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -763,12 +763,12 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, stream_blurbs_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.stream_blurbs({ name: name, expire_time: expire_time }) do |response, operation|
+      client_stub.stream_blurbs({ name: name, expire_time: expire_time }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -777,7 +777,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client.stream_blurbs name: name, expire_time: expire_time do |response, operation|
+      client_stub.stream_blurbs name: name, expire_time: expire_time do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -786,7 +786,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |response, operation|
+      client_stub.stream_blurbs ::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -795,7 +795,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client.stream_blurbs({ name: name, expire_time: expire_time }, grpc_options) do |response, operation|
+      client_stub.stream_blurbs({ name: name, expire_time: expire_time }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -804,7 +804,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), grpc_options) do |response, operation|
+      client_stub.stream_blurbs(::Google::Showcase::V1beta1::StreamBlurbsRequest.new(name: name, expire_time: expire_time), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -837,7 +837,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, send_blurbs_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -845,7 +845,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       enum_input = [request_hash, request_proto].to_enum
-      client.send_blurbs enum_input do |response, operation|
+      client_stub.send_blurbs enum_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -854,7 +854,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       stream_input = Gapic::StreamInput.new
-      client.send_blurbs stream_input do |response, operation|
+      client_stub.send_blurbs stream_input do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -866,7 +866,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       enum_input = [request_hash, request_proto].to_enum
-      client.send_blurbs enum_input, grpc_options do |response, operation|
+      client_stub.send_blurbs enum_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -875,7 +875,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { parent: parent, blurb: blurb }
       request_proto = ::Google::Showcase::V1beta1::CreateBlurbRequest.new parent: parent, blurb: blurb
       stream_input = Gapic::StreamInput.new
-      client.send_blurbs stream_input, grpc_options do |response, operation|
+      client_stub.send_blurbs stream_input, grpc_options do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -914,7 +914,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, connect_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
         config.credentials = grpc_channel
       end
 
@@ -922,7 +922,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       enum_input = [request_hash, request_proto].to_enum
-      client.connect enum_input do |response, operation|
+      client_stub.connect enum_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -934,7 +934,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       stream_input = Gapic::StreamInput.new
-      client.connect stream_input do |response, operation|
+      client_stub.connect stream_input do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -949,7 +949,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       enum_input = [request_hash, request_proto].to_enum
-      client.connect enum_input, grpc_options do |response, operation|
+      client_stub.connect enum_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r
@@ -961,7 +961,7 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       request_hash = { config: config }
       request_proto = ::Google::Showcase::V1beta1::ConnectRequest.new config: config
       stream_input = Gapic::StreamInput.new
-      client.connect stream_input, grpc_options do |response, operation|
+      client_stub.connect stream_input, grpc_options do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::StreamBlurbsResponse, r

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_create_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_sequence_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_sequence({ sequence: sequence }) do |_result, response|
+        c.create_sequence({ sequence: sequence }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_sequence sequence: sequence do |_result, response|
+        c.create_sequence sequence: sequence do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |_result, response|
+        c.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_sequence({ sequence: sequence }, call_options) do |_result, response|
+        c.create_sequence({ sequence: sequence }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), call_options) do |_result, response|
+        c.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_create_streaming_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_streaming_sequence_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |_result, response|
+        c.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_streaming_sequence streaming_sequence: streaming_sequence do |_result, response|
+        c.create_streaming_sequence streaming_sequence: streaming_sequence do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |_result, response|
+        c.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }, call_options) do |_result, response|
+        c.create_streaming_sequence({ streaming_sequence: streaming_sequence }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), call_options) do |_result, response|
+        c.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -213,32 +213,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_get_sequence_report_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_sequence_report_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_sequence_report({ name: name }) do |_result, response|
+        c.get_sequence_report({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_sequence_report name: name do |_result, response|
+        c.get_sequence_report name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |_result, response|
+        c.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_sequence_report({ name: name }, call_options) do |_result, response|
+        c.get_sequence_report({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), call_options) do |_result, response|
+        c.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -267,32 +267,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_get_streaming_sequence_report_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_streaming_sequence_report_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_streaming_sequence_report({ name: name }) do |_result, response|
+        c.get_streaming_sequence_report({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_streaming_sequence_report name: name do |_result, response|
+        c.get_streaming_sequence_report name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |_result, response|
+        c.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_streaming_sequence_report({ name: name }, call_options) do |_result, response|
+        c.get_streaming_sequence_report({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), call_options) do |_result, response|
+        c.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -321,32 +321,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_attempt_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, attempt_sequence_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.attempt_sequence({ name: name }) do |_result, response|
+        c.attempt_sequence({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.attempt_sequence name: name do |_result, response|
+        c.attempt_sequence name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |_result, response|
+        c.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.attempt_sequence({ name: name }, call_options) do |_result, response|
+        c.attempt_sequence({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), call_options) do |_result, response|
+        c.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -376,32 +376,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_attempt_streaming_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, attempt_streaming_sequence_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |_result, response|
+        c.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use named arguments
-        client_stub.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |_result, response|
+        c.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object
-        client_stub.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |_result, response|
+        c.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use hash object with options
-        client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, call_options) do |_result, response|
+        c.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object with options
-        client_stub.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), call_options) do |_result, response|
+        c.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_create_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_sequence_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_sequence({ sequence: sequence }) do |_result, response|
+        client_stub.create_sequence({ sequence: sequence }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_sequence sequence: sequence do |_result, response|
+        client_stub.create_sequence sequence: sequence do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |_result, response|
+        client_stub.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_sequence({ sequence: sequence }, call_options) do |_result, response|
+        client_stub.create_sequence({ sequence: sequence }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), call_options) do |_result, response|
+        client_stub.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_create_streaming_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_streaming_sequence_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |_result, response|
+        client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_streaming_sequence streaming_sequence: streaming_sequence do |_result, response|
+        client_stub.create_streaming_sequence streaming_sequence: streaming_sequence do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |_result, response|
+        client_stub.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_streaming_sequence({ streaming_sequence: streaming_sequence }, call_options) do |_result, response|
+        client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), call_options) do |_result, response|
+        client_stub.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -213,32 +213,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_get_sequence_report_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_sequence_report_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_sequence_report({ name: name }) do |_result, response|
+        client_stub.get_sequence_report({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_sequence_report name: name do |_result, response|
+        client_stub.get_sequence_report name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |_result, response|
+        client_stub.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_sequence_report({ name: name }, call_options) do |_result, response|
+        client_stub.get_sequence_report({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -267,32 +267,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_get_streaming_sequence_report_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_streaming_sequence_report_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_streaming_sequence_report({ name: name }) do |_result, response|
+        client_stub.get_streaming_sequence_report({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_streaming_sequence_report name: name do |_result, response|
+        client_stub.get_streaming_sequence_report name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |_result, response|
+        client_stub.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_streaming_sequence_report({ name: name }, call_options) do |_result, response|
+        client_stub.get_streaming_sequence_report({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -321,32 +321,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_attempt_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, attempt_sequence_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.attempt_sequence({ name: name }) do |_result, response|
+        client_stub.attempt_sequence({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.attempt_sequence name: name do |_result, response|
+        client_stub.attempt_sequence name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |_result, response|
+        client_stub.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.attempt_sequence({ name: name }, call_options) do |_result, response|
+        client_stub.attempt_sequence({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), call_options) do |_result, response|
+        client_stub.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -376,32 +376,32 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     ::Google::Showcase::V1beta1::SequenceService::Rest::ServiceStub.stub :transcode_attempt_streaming_sequence_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, attempt_streaming_sequence_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::SequenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |_result, response|
+        client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use named arguments
-        client.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |_result, response|
+        client_stub.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object
-        client.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |_result, response|
+        client_stub.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use hash object with options
-        client.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, call_options) do |_result, response|
+        client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 
         # Use protobuf object with options
-        client.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), call_options) do |_result, response|
+        client_stub.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end.first
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_sequence_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_sequence({ sequence: sequence }) do |response, operation|
+      client_stub.create_sequence({ sequence: sequence }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_sequence sequence: sequence do |response, operation|
+      client_stub.create_sequence sequence: sequence do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |response, operation|
+      client_stub.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_sequence({ sequence: sequence }, grpc_options) do |response, operation|
+      client_stub.create_sequence({ sequence: sequence }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), grpc_options) do |response, operation|
+      client_stub.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_streaming_sequence_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |response, operation|
+      client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_streaming_sequence streaming_sequence: streaming_sequence do |response, operation|
+      client_stub.create_streaming_sequence streaming_sequence: streaming_sequence do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |response, operation|
+      client_stub.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_streaming_sequence({ streaming_sequence: streaming_sequence }, grpc_options) do |response, operation|
+      client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), grpc_options) do |response, operation|
+      client_stub.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -206,36 +206,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_sequence_report_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_sequence_report({ name: name }) do |response, operation|
+      client_stub.get_sequence_report({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_sequence_report name: name do |response, operation|
+      client_stub.get_sequence_report name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |response, operation|
+      client_stub.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_sequence_report({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_sequence_report({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_streaming_sequence_report_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_streaming_sequence_report({ name: name }) do |response, operation|
+      client_stub.get_streaming_sequence_report({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_streaming_sequence_report name: name do |response, operation|
+      client_stub.get_streaming_sequence_report name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |response, operation|
+      client_stub.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_streaming_sequence_report({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_streaming_sequence_report({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -322,36 +322,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, attempt_sequence_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.attempt_sequence({ name: name }) do |response, operation|
+      client_stub.attempt_sequence({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.attempt_sequence name: name do |response, operation|
+      client_stub.attempt_sequence name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |response, operation|
+      client_stub.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.attempt_sequence({ name: name }, grpc_options) do |response, operation|
+      client_stub.attempt_sequence({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -382,12 +382,12 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, attempt_streaming_sequence_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |response, operation|
+      client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -396,7 +396,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |response, operation|
+      client_stub.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -405,7 +405,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |response, operation|
+      client_stub.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -414,7 +414,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, grpc_options) do |response, operation|
+      client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -423,7 +423,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), grpc_options) do |response, operation|
+      client_stub.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_sequence_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_sequence({ sequence: sequence }) do |response, operation|
+      c.create_sequence({ sequence: sequence }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_sequence sequence: sequence do |response, operation|
+      c.create_sequence sequence: sequence do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |response, operation|
+      c.create_sequence ::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_sequence({ sequence: sequence }, grpc_options) do |response, operation|
+      c.create_sequence({ sequence: sequence }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), grpc_options) do |response, operation|
+      c.create_sequence(::Google::Showcase::V1beta1::CreateSequenceRequest.new(sequence: sequence), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_streaming_sequence_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |response, operation|
+      c.create_streaming_sequence({ streaming_sequence: streaming_sequence }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_streaming_sequence streaming_sequence: streaming_sequence do |response, operation|
+      c.create_streaming_sequence streaming_sequence: streaming_sequence do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |response, operation|
+      c.create_streaming_sequence ::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_streaming_sequence({ streaming_sequence: streaming_sequence }, grpc_options) do |response, operation|
+      c.create_streaming_sequence({ streaming_sequence: streaming_sequence }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), grpc_options) do |response, operation|
+      c.create_streaming_sequence(::Google::Showcase::V1beta1::CreateStreamingSequenceRequest.new(streaming_sequence: streaming_sequence), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -206,36 +206,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_sequence_report_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_sequence_report({ name: name }) do |response, operation|
+      c.get_sequence_report({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_sequence_report name: name do |response, operation|
+      c.get_sequence_report name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |response, operation|
+      c.get_sequence_report ::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_sequence_report({ name: name }, grpc_options) do |response, operation|
+      c.get_sequence_report({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_sequence_report(::Google::Showcase::V1beta1::GetSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_streaming_sequence_report_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_streaming_sequence_report({ name: name }) do |response, operation|
+      c.get_streaming_sequence_report({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_streaming_sequence_report name: name do |response, operation|
+      c.get_streaming_sequence_report name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |response, operation|
+      c.get_streaming_sequence_report ::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_streaming_sequence_report({ name: name }, grpc_options) do |response, operation|
+      c.get_streaming_sequence_report({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_streaming_sequence_report(::Google::Showcase::V1beta1::GetStreamingSequenceReportRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -322,36 +322,36 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, attempt_sequence_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.attempt_sequence({ name: name }) do |response, operation|
+      c.attempt_sequence({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.attempt_sequence name: name do |response, operation|
+      c.attempt_sequence name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |response, operation|
+      c.attempt_sequence ::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.attempt_sequence({ name: name }, grpc_options) do |response, operation|
+      c.attempt_sequence({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), grpc_options) do |response, operation|
+      c.attempt_sequence(::Google::Showcase::V1beta1::AttemptSequenceRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -382,12 +382,12 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, attempt_streaming_sequence_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::SequenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |response, operation|
+      c.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -396,7 +396,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use named arguments
-      client_stub.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |response, operation|
+      c.attempt_streaming_sequence name: name, last_fail_index: last_fail_index do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -405,7 +405,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object
-      client_stub.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |response, operation|
+      c.attempt_streaming_sequence ::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -414,7 +414,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use hash object with options
-      client_stub.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, grpc_options) do |response, operation|
+      c.attempt_streaming_sequence({ name: name, last_fail_index: last_fail_index }, grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r
@@ -423,7 +423,7 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
       end
 
       # Use protobuf object with options
-      client_stub.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), grpc_options) do |response, operation|
+      c.attempt_streaming_sequence(::Google::Showcase::V1beta1::AttemptStreamingSequenceRequest.new(name: name, last_fail_index: last_fail_index), grpc_options) do |response, operation|
         assert_kind_of Enumerable, response
         response.to_a.each do |r|
           assert_kind_of ::Google::Showcase::V1beta1::AttemptStreamingSequenceResponse, r

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_create_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_session_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.create_session({ session: session }) do |_result, response|
+        c.create_session({ session: session }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.create_session session: session do |_result, response|
+        c.create_session session: session do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |_result, response|
+        c.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.create_session({ session: session }, call_options) do |_result, response|
+        c.create_session({ session: session }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), call_options) do |_result, response|
+        c.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_get_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_session_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_session({ name: name }) do |_result, response|
+        c.get_session({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_session name: name do |_result, response|
+        c.get_session name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |_result, response|
+        c.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_session({ name: name }, call_options) do |_result, response|
+        c.get_session({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), call_options) do |_result, response|
+        c.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -214,32 +214,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_list_sessions_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_sessions_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_sessions({ page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_sessions({ page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_sessions page_size: page_size, page_token: page_token do |_result, response|
+        c.list_sessions page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_sessions({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_sessions({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_delete_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_session_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_session({ name: name }) do |_result, response|
+        c.delete_session({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_session name: name do |_result, response|
+        c.delete_session name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |_result, response|
+        c.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_session({ name: name }, call_options) do |_result, response|
+        c.delete_session({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), call_options) do |_result, response|
+        c.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -322,32 +322,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_report_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, report_session_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.report_session({ name: name }) do |_result, response|
+        c.report_session({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.report_session name: name do |_result, response|
+        c.report_session name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |_result, response|
+        c.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.report_session({ name: name }, call_options) do |_result, response|
+        c.report_session({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), call_options) do |_result, response|
+        c.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -378,32 +378,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_list_tests_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_tests_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.list_tests parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_tests parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -432,32 +432,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_delete_test_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_test_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.delete_test({ name: name }) do |_result, response|
+        c.delete_test({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.delete_test name: name do |_result, response|
+        c.delete_test name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |_result, response|
+        c.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.delete_test({ name: name }, call_options) do |_result, response|
+        c.delete_test({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), call_options) do |_result, response|
+        c.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -488,32 +488,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_verify_test_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, verify_test_client_stub do
         # Create client
-        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        c = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.verify_test({ name: name, answer: answer, answers: answers }) do |_result, response|
+        c.verify_test({ name: name, answer: answer, answers: answers }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.verify_test name: name, answer: answer, answers: answers do |_result, response|
+        c.verify_test name: name, answer: answer, answers: answers do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |_result, response|
+        c.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.verify_test({ name: name, answer: answer, answers: answers }, call_options) do |_result, response|
+        c.verify_test({ name: name, answer: answer, answers: answers }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), call_options) do |_result, response|
+        c.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_rest_test.rb
@@ -105,32 +105,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_create_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_session_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_session({ session: session }) do |_result, response|
+        client_stub.create_session({ session: session }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_session session: session do |_result, response|
+        client_stub.create_session session: session do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |_result, response|
+        client_stub.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_session({ session: session }, call_options) do |_result, response|
+        client_stub.create_session({ session: session }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), call_options) do |_result, response|
+        client_stub.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_get_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_session_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_session({ name: name }) do |_result, response|
+        client_stub.get_session({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_session name: name do |_result, response|
+        client_stub.get_session name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |_result, response|
+        client_stub.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_session({ name: name }, call_options) do |_result, response|
+        client_stub.get_session({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), call_options) do |_result, response|
+        client_stub.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -214,32 +214,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_list_sessions_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_sessions_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_sessions({ page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_sessions({ page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_sessions page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_sessions page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_sessions({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_sessions({ page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_delete_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_session_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_session({ name: name }) do |_result, response|
+        client_stub.delete_session({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_session name: name do |_result, response|
+        client_stub.delete_session name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |_result, response|
+        client_stub.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_session({ name: name }, call_options) do |_result, response|
+        client_stub.delete_session({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -322,32 +322,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_report_session_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, report_session_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.report_session({ name: name }) do |_result, response|
+        client_stub.report_session({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.report_session name: name do |_result, response|
+        client_stub.report_session name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |_result, response|
+        client_stub.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.report_session({ name: name }, call_options) do |_result, response|
+        client_stub.report_session({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), call_options) do |_result, response|
+        client_stub.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -378,32 +378,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_list_tests_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_tests_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_tests parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        client_stub.list_tests parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        client_stub.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        client_stub.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -432,32 +432,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_delete_test_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_test_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_test({ name: name }) do |_result, response|
+        client_stub.delete_test({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_test name: name do |_result, response|
+        client_stub.delete_test name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |_result, response|
+        client_stub.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_test({ name: name }, call_options) do |_result, response|
+        client_stub.delete_test({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), call_options) do |_result, response|
+        client_stub.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -488,32 +488,32 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     ::Google::Showcase::V1beta1::Testing::Rest::ServiceStub.stub :transcode_verify_test_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, verify_test_client_stub do
         # Create client
-        client = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
+        client_stub = ::Google::Showcase::V1beta1::Testing::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.verify_test({ name: name, answer: answer, answers: answers }) do |_result, response|
+        client_stub.verify_test({ name: name, answer: answer, answers: answers }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.verify_test name: name, answer: answer, answers: answers do |_result, response|
+        client_stub.verify_test name: name, answer: answer, answers: answers do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |_result, response|
+        client_stub.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.verify_test({ name: name, answer: answer, answers: answers }, call_options) do |_result, response|
+        client_stub.verify_test({ name: name, answer: answer, answers: answers }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), call_options) do |_result, response|
+        client_stub.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_session_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_session({ session: session }) do |response, operation|
+      client_stub.create_session({ session: session }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_session session: session do |response, operation|
+      client_stub.create_session session: session do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |response, operation|
+      client_stub.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_session({ session: session }, grpc_options) do |response, operation|
+      client_stub.create_session({ session: session }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), grpc_options) do |response, operation|
+      client_stub.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_session_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_session({ name: name }) do |response, operation|
+      client_stub.get_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_session name: name do |response, operation|
+      client_stub.get_session name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |response, operation|
+      client_stub.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_session({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_session({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -208,40 +208,40 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_sessions_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_sessions({ page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_sessions({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_sessions page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_sessions page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_sessions({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_sessions({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -271,36 +271,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_session_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_session({ name: name }) do |response, operation|
+      client_stub.delete_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_session name: name do |response, operation|
+      client_stub.delete_session name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |response, operation|
+      client_stub.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_session({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_session({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, report_session_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.report_session({ name: name }) do |response, operation|
+      client_stub.report_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.report_session name: name do |response, operation|
+      client_stub.report_session name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |response, operation|
+      client_stub.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.report_session({ name: name }, grpc_options) do |response, operation|
+      client_stub.report_session({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,40 +391,40 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_tests_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_tests parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client_stub.list_tests parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      client_stub.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      client_stub.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -454,36 +454,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_test_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_test({ name: name }) do |response, operation|
+      client_stub.delete_test({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_test name: name do |response, operation|
+      client_stub.delete_test name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |response, operation|
+      client_stub.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_test({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_test({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -516,36 +516,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, verify_test_client_stub do
       # Create client
-      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.verify_test({ name: name, answer: answer, answers: answers }) do |response, operation|
+      client_stub.verify_test({ name: name, answer: answer, answers: answers }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.verify_test name: name, answer: answer, answers: answers do |response, operation|
+      client_stub.verify_test name: name, answer: answer, answers: answers do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |response, operation|
+      client_stub.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.verify_test({ name: name, answer: answer, answers: answers }, grpc_options) do |response, operation|
+      client_stub.verify_test({ name: name, answer: answer, answers: answers }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), grpc_options) do |response, operation|
+      client_stub.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -90,36 +90,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_session_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.create_session({ session: session }) do |response, operation|
+      c.create_session({ session: session }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.create_session session: session do |response, operation|
+      c.create_session session: session do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |response, operation|
+      c.create_session ::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.create_session({ session: session }, grpc_options) do |response, operation|
+      c.create_session({ session: session }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), grpc_options) do |response, operation|
+      c.create_session(::Google::Showcase::V1beta1::CreateSessionRequest.new(session: session), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_session_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_session({ name: name }) do |response, operation|
+      c.get_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_session name: name do |response, operation|
+      c.get_session name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |response, operation|
+      c.get_session ::Google::Showcase::V1beta1::GetSessionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_session({ name: name }, grpc_options) do |response, operation|
+      c.get_session({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_session(::Google::Showcase::V1beta1::GetSessionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -208,40 +208,40 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_sessions_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_sessions({ page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_sessions({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_sessions page_size: page_size, page_token: page_token do |response, operation|
+      c.list_sessions page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_sessions ::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_sessions({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_sessions({ page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_sessions(::Google::Showcase::V1beta1::ListSessionsRequest.new(page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -271,36 +271,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_session_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_session({ name: name }) do |response, operation|
+      c.delete_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_session name: name do |response, operation|
+      c.delete_session name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |response, operation|
+      c.delete_session ::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_session({ name: name }, grpc_options) do |response, operation|
+      c.delete_session({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_session(::Google::Showcase::V1beta1::DeleteSessionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, report_session_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.report_session({ name: name }) do |response, operation|
+      c.report_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.report_session name: name do |response, operation|
+      c.report_session name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |response, operation|
+      c.report_session ::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.report_session({ name: name }, grpc_options) do |response, operation|
+      c.report_session({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), grpc_options) do |response, operation|
+      c.report_session(::Google::Showcase::V1beta1::ReportSessionRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,40 +391,40 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_tests_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_tests parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_tests parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_tests ::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_tests({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_tests(::Google::Showcase::V1beta1::ListTestsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -454,36 +454,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_test_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_test({ name: name }) do |response, operation|
+      c.delete_test({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_test name: name do |response, operation|
+      c.delete_test name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |response, operation|
+      c.delete_test ::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_test({ name: name }, grpc_options) do |response, operation|
+      c.delete_test({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_test(::Google::Showcase::V1beta1::DeleteTestRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -516,36 +516,36 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, verify_test_client_stub do
       # Create client
-      client_stub = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+      c = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.verify_test({ name: name, answer: answer, answers: answers }) do |response, operation|
+      c.verify_test({ name: name, answer: answer, answers: answers }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.verify_test name: name, answer: answer, answers: answers do |response, operation|
+      c.verify_test name: name, answer: answer, answers: answers do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |response, operation|
+      c.verify_test ::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.verify_test({ name: name, answer: answer, answers: answers }, grpc_options) do |response, operation|
+      c.verify_test({ name: name, answer: answer, answers: answers }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), grpc_options) do |response, operation|
+      c.verify_test(::Google::Showcase::V1beta1::VerifyTestRequest.new(name: name, answer: answer, answers: answers), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::ClientTest < Minitest:
     ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::ServiceStub.stub :transcode_no_retry_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, no_retry_method_client_stub do
         # Create client
-        client_stub = ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::Client.new do |config|
+        c = ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.no_retry_method({  }) do |_result, response|
+        c.no_retry_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
+        c.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.no_retry_method({  }, call_options) do |_result, response|
+        c.no_retry_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
+        c.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::ClientTest < Minitest:
     ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::ServiceStub.stub :transcode_no_retry_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, no_retry_method_client_stub do
         # Create client
-        client = ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::Client.new do |config|
+        client_stub = ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.no_retry_method({  }) do |_result, response|
+        client_stub.no_retry_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
+        client_stub.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.no_retry_method({  }, call_options) do |_result, response|
+        client_stub.no_retry_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
+        client_stub.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
@@ -88,30 +88,30 @@ class ::Testing::GrpcServiceConfig::ServiceNoRetry::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, no_retry_method_client_stub do
       # Create client
-      client_stub = ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.new do |config|
+      c = ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.no_retry_method({  }) do |response, operation|
+      c.no_retry_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
+      c.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.no_retry_method({  }, grpc_options) do |response, operation|
+      c.no_retry_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
+      c.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
@@ -88,30 +88,30 @@ class ::Testing::GrpcServiceConfig::ServiceNoRetry::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, no_retry_method_client_stub do
       # Create client
-      client = ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.new do |config|
+      client_stub = ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.no_retry_method({  }) do |response, operation|
+      client_stub.no_retry_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
+      client_stub.no_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.no_retry_method({  }, grpc_options) do |response, operation|
+      client_stub.no_retry_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
+      client_stub.no_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ClientTest < Minit
     ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ServiceStub.stub :transcode_service_level_retry_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, service_level_retry_method_client_stub do
         # Create client
-        client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
+        c = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.service_level_retry_method({  }) do |_result, response|
+        c.service_level_retry_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
+        c.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.service_level_retry_method({  }, call_options) do |_result, response|
+        c.service_level_retry_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
+        c.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -152,27 +152,27 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ClientTest < Minit
     ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ServiceStub.stub :transcode_method_level_retry_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, method_level_retry_method_client_stub do
         # Create client
-        client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
+        c = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.method_level_retry_method({  }) do |_result, response|
+        c.method_level_retry_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
+        c.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.method_level_retry_method({  }, call_options) do |_result, response|
+        c.method_level_retry_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
+        c.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ClientTest < Minit
     ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ServiceStub.stub :transcode_service_level_retry_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, service_level_retry_method_client_stub do
         # Create client
-        client = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
+        client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.service_level_retry_method({  }) do |_result, response|
+        client_stub.service_level_retry_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
+        client_stub.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.service_level_retry_method({  }, call_options) do |_result, response|
+        client_stub.service_level_retry_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
+        client_stub.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -152,27 +152,27 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ClientTest < Minit
     ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ServiceStub.stub :transcode_method_level_retry_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, method_level_retry_method_client_stub do
         # Create client
-        client = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
+        client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.method_level_retry_method({  }) do |_result, response|
+        client_stub.method_level_retry_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
+        client_stub.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.method_level_retry_method({  }, call_options) do |_result, response|
+        client_stub.method_level_retry_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
+        client_stub.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
@@ -88,30 +88,30 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::T
 
     Gapic::ServiceStub.stub :new, service_level_retry_method_client_stub do
       # Create client
-      client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
+      c = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.service_level_retry_method({  }) do |response, operation|
+      c.service_level_retry_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
+      c.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.service_level_retry_method({  }, grpc_options) do |response, operation|
+      c.service_level_retry_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
+      c.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -138,30 +138,30 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::T
 
     Gapic::ServiceStub.stub :new, method_level_retry_method_client_stub do
       # Create client
-      client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
+      c = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.method_level_retry_method({  }) do |response, operation|
+      c.method_level_retry_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
+      c.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.method_level_retry_method({  }, grpc_options) do |response, operation|
+      c.method_level_retry_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
+      c.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
@@ -88,30 +88,30 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::T
 
     Gapic::ServiceStub.stub :new, service_level_retry_method_client_stub do
       # Create client
-      client = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
+      client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.service_level_retry_method({  }) do |response, operation|
+      client_stub.service_level_retry_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
+      client_stub.service_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.service_level_retry_method({  }, grpc_options) do |response, operation|
+      client_stub.service_level_retry_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
+      client_stub.service_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -138,30 +138,30 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::T
 
     Gapic::ServiceStub.stub :new, method_level_retry_method_client_stub do
       # Create client
-      client = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
+      client_stub = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.method_level_retry_method({  }) do |response, operation|
+      client_stub.method_level_retry_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
+      client_stub.method_level_retry_method ::Testing::GrpcServiceConfig::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.method_level_retry_method({  }, grpc_options) do |response, operation|
+      client_stub.method_level_retry_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
+      client_stub.method_level_retry_method(::Testing::GrpcServiceConfig::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_operations_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_operations_test.rb
@@ -99,40 +99,40 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_operations_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_operations_test.rb
@@ -99,40 +99,40 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::OperationsTest < Minitest:
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::ClientTest < Minites
     ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::ServiceStub.stub :transcode_call_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, call_method_client_stub do
         # Create client
-        client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::Client.new do |config|
+        c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.call_method({  }) do |_result, response|
+        c.call_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.call_method ::Testing::Mixins::Request.new() do |_result, response|
+        c.call_method ::Testing::Mixins::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.call_method({  }, call_options) do |_result, response|
+        c.call_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
+        c.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::ClientTest < Minites
     ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::ServiceStub.stub :transcode_call_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, call_method_client_stub do
         # Create client
-        client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::Client.new do |config|
+        client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.call_method({  }) do |_result, response|
+        client_stub.call_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.call_method ::Testing::Mixins::Request.new() do |_result, response|
+        client_stub.call_method ::Testing::Mixins::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.call_method({  }, call_options) do |_result, response|
+        client_stub.call_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
+        client_stub.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_test.rb
@@ -88,30 +88,30 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, call_method_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.call_method({  }) do |response, operation|
+      client_stub.call_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.call_method ::Testing::Mixins::Request.new() do |response, operation|
+      client_stub.call_method ::Testing::Mixins::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.call_method({  }, grpc_options) do |response, operation|
+      client_stub.call_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
+      client_stub.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -138,33 +138,33 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, lro_method_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.lro_method({  }) do |response, operation|
+      client_stub.lro_method({  }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.lro_method ::Testing::Mixins::Request.new() do |response, operation|
+      client_stub.lro_method ::Testing::Mixins::Request.new() do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.lro_method({  }, grpc_options) do |response, operation|
+      client_stub.lro_method({  }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.lro_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
+      client_stub.lro_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_test.rb
@@ -88,30 +88,30 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, call_method_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
+      c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.call_method({  }) do |response, operation|
+      c.call_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.call_method ::Testing::Mixins::Request.new() do |response, operation|
+      c.call_method ::Testing::Mixins::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.call_method({  }, grpc_options) do |response, operation|
+      c.call_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
+      c.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -138,33 +138,33 @@ class ::Testing::Mixins::ServiceWithLocAndNonRestOps::ClientTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, lro_method_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
+      c = ::Testing::Mixins::ServiceWithLocAndNonRestOps::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.lro_method({  }) do |response, operation|
+      c.lro_method({  }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.lro_method ::Testing::Mixins::Request.new() do |response, operation|
+      c.lro_method ::Testing::Mixins::Request.new() do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.lro_method({  }, grpc_options) do |response, operation|
+      c.lro_method({  }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.lro_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
+      c.lro_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::Mixins::ServiceWithLoc::Rest::ClientTest < Minitest::Test
     ::Testing::Mixins::ServiceWithLoc::Rest::ServiceStub.stub :transcode_call_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, call_method_client_stub do
         # Create client
-        client = ::Testing::Mixins::ServiceWithLoc::Rest::Client.new do |config|
+        client_stub = ::Testing::Mixins::ServiceWithLoc::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.call_method({  }) do |_result, response|
+        client_stub.call_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.call_method ::Testing::Mixins::Request.new() do |_result, response|
+        client_stub.call_method ::Testing::Mixins::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.call_method({  }, call_options) do |_result, response|
+        client_stub.call_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
+        client_stub.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_rest_test.rb
@@ -104,27 +104,27 @@ class ::Testing::Mixins::ServiceWithLoc::Rest::ClientTest < Minitest::Test
     ::Testing::Mixins::ServiceWithLoc::Rest::ServiceStub.stub :transcode_call_method_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, call_method_client_stub do
         # Create client
-        client_stub = ::Testing::Mixins::ServiceWithLoc::Rest::Client.new do |config|
+        c = ::Testing::Mixins::ServiceWithLoc::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.call_method({  }) do |_result, response|
+        c.call_method({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.call_method ::Testing::Mixins::Request.new() do |_result, response|
+        c.call_method ::Testing::Mixins::Request.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.call_method({  }, call_options) do |_result, response|
+        c.call_method({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
+        c.call_method(::Testing::Mixins::Request.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
@@ -88,30 +88,30 @@ class ::Testing::Mixins::ServiceWithLoc::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, call_method_client_stub do
       # Create client
-      client_stub = ::Testing::Mixins::ServiceWithLoc::Client.new do |config|
+      c = ::Testing::Mixins::ServiceWithLoc::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.call_method({  }) do |response, operation|
+      c.call_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.call_method ::Testing::Mixins::Request.new() do |response, operation|
+      c.call_method ::Testing::Mixins::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.call_method({  }, grpc_options) do |response, operation|
+      c.call_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
+      c.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
@@ -88,30 +88,30 @@ class ::Testing::Mixins::ServiceWithLoc::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, call_method_client_stub do
       # Create client
-      client = ::Testing::Mixins::ServiceWithLoc::Client.new do |config|
+      client_stub = ::Testing::Mixins::ServiceWithLoc::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.call_method({  }) do |response, operation|
+      client_stub.call_method({  }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.call_method ::Testing::Mixins::Request.new() do |response, operation|
+      client_stub.call_method ::Testing::Mixins::Request.new() do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.call_method({  }, grpc_options) do |response, operation|
+      client_stub.call_method({  }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
+      client_stub.call_method(::Testing::Mixins::Request.new(), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_operations_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_operations_test.rb
@@ -99,40 +99,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      client_stub.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      client_stub.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      client_stub.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      client_stub.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      client_stub.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      client_stub.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_operations_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_operations_test.rb
@@ -99,40 +99,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -162,40 +162,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -225,36 +225,36 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -283,36 +283,36 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -343,40 +343,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_rest_test.rb
@@ -105,32 +105,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_plain_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_lro_rpc_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.plain_lro_rpc({ request_id: request_id }) do |_result, response|
+        c.plain_lro_rpc({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.plain_lro_rpc request_id: request_id do |_result, response|
+        c.plain_lro_rpc request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        c.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
+        c.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        c.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_another_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, another_lro_rpc_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.another_lro_rpc({ request_id: request_id }) do |_result, response|
+        c.another_lro_rpc({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.another_lro_rpc request_id: request_id do |_result, response|
+        c.another_lro_rpc request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |_result, response|
+        c.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.another_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
+        c.another_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), call_options) do |_result, response|
+        c.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -212,27 +212,27 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_non_copy_another_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, non_copy_another_lro_rpc_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.non_copy_another_lro_rpc({  }) do |_result, response|
+        c.non_copy_another_lro_rpc({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |_result, response|
+        c.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.non_copy_another_lro_rpc({  }, call_options) do |_result, response|
+        c.non_copy_another_lro_rpc({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), call_options) do |_result, response|
+        c.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -261,32 +261,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_aip_lro_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, aip_lro_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.aip_lro({ request_id: request_id }) do |_result, response|
+        c.aip_lro({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.aip_lro request_id: request_id do |_result, response|
+        c.aip_lro request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        c.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.aip_lro({ request_id: request_id }, call_options) do |_result, response|
+        c.aip_lro({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        c.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -315,32 +315,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_no_lro_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, no_lro_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.no_lro({ request_id: request_id }) do |_result, response|
+        c.no_lro({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.no_lro request_id: request_id do |_result, response|
+        c.no_lro request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        c.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.no_lro({ request_id: request_id }, call_options) do |_result, response|
+        c.no_lro({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        c.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_rest_test.rb
@@ -105,32 +105,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_plain_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_lro_rpc_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.plain_lro_rpc({ request_id: request_id }) do |_result, response|
+        client_stub.plain_lro_rpc({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.plain_lro_rpc request_id: request_id do |_result, response|
+        client_stub.plain_lro_rpc request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
+        client_stub.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -159,32 +159,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_another_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, another_lro_rpc_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.another_lro_rpc({ request_id: request_id }) do |_result, response|
+        client_stub.another_lro_rpc({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.another_lro_rpc request_id: request_id do |_result, response|
+        client_stub.another_lro_rpc request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |_result, response|
+        client_stub.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.another_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
+        client_stub.another_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), call_options) do |_result, response|
+        client_stub.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -212,27 +212,27 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_non_copy_another_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, non_copy_another_lro_rpc_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.non_copy_another_lro_rpc({  }) do |_result, response|
+        client_stub.non_copy_another_lro_rpc({  }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |_result, response|
+        client_stub.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.non_copy_another_lro_rpc({  }, call_options) do |_result, response|
+        client_stub.non_copy_another_lro_rpc({  }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), call_options) do |_result, response|
+        client_stub.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -261,32 +261,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_aip_lro_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, aip_lro_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.aip_lro({ request_id: request_id }) do |_result, response|
+        client_stub.aip_lro({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.aip_lro request_id: request_id do |_result, response|
+        client_stub.aip_lro request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        client_stub.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.aip_lro({ request_id: request_id }, call_options) do |_result, response|
+        client_stub.aip_lro({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        client_stub.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -315,32 +315,32 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ServiceStub.stub :transcode_no_lro_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, no_lro_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.no_lro({ request_id: request_id }) do |_result, response|
+        client_stub.no_lro({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.no_lro request_id: request_id do |_result, response|
+        client_stub.no_lro request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        client_stub.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.no_lro({ request_id: request_id }, call_options) do |_result, response|
+        client_stub.no_lro({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        client_stub.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
@@ -90,40 +90,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, plain_lro_rpc_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain_lro_rpc({ request_id: request_id }) do |response, operation|
+      client_stub.plain_lro_rpc({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain_lro_rpc request_id: request_id do |response, operation|
+      client_stub.plain_lro_rpc request_id: request_id do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
+      client_stub.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
@@ -153,40 +153,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, another_lro_rpc_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.another_lro_rpc({ request_id: request_id }) do |response, operation|
+      client_stub.another_lro_rpc({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.another_lro_rpc request_id: request_id do |response, operation|
+      client_stub.another_lro_rpc request_id: request_id do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |response, operation|
+      client_stub.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.another_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
+      client_stub.another_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), grpc_options) do |response, operation|
+      client_stub.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
@@ -214,33 +214,33 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, non_copy_another_lro_rpc_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.non_copy_another_lro_rpc({  }) do |response, operation|
+      client_stub.non_copy_another_lro_rpc({  }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |response, operation|
+      client_stub.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.non_copy_another_lro_rpc({  }, grpc_options) do |response, operation|
+      client_stub.non_copy_another_lro_rpc({  }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), grpc_options) do |response, operation|
+      client_stub.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
@@ -270,40 +270,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, aip_lro_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.aip_lro({ request_id: request_id }) do |response, operation|
+      client_stub.aip_lro({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.aip_lro request_id: request_id do |response, operation|
+      client_stub.aip_lro request_id: request_id do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      client_stub.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.aip_lro({ request_id: request_id }, grpc_options) do |response, operation|
+      client_stub.aip_lro({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      client_stub.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -333,36 +333,36 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, no_lro_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.no_lro({ request_id: request_id }) do |response, operation|
+      client_stub.no_lro({ request_id: request_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.no_lro request_id: request_id do |response, operation|
+      client_stub.no_lro request_id: request_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      client_stub.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.no_lro({ request_id: request_id }, grpc_options) do |response, operation|
+      client_stub.no_lro({ request_id: request_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      client_stub.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
@@ -90,40 +90,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, plain_lro_rpc_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain_lro_rpc({ request_id: request_id }) do |response, operation|
+      c.plain_lro_rpc({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain_lro_rpc request_id: request_id do |response, operation|
+      c.plain_lro_rpc request_id: request_id do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      c.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
+      c.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      c.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
@@ -153,40 +153,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, another_lro_rpc_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.another_lro_rpc({ request_id: request_id }) do |response, operation|
+      c.another_lro_rpc({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.another_lro_rpc request_id: request_id do |response, operation|
+      c.another_lro_rpc request_id: request_id do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |response, operation|
+      c.another_lro_rpc ::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.another_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
+      c.another_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), grpc_options) do |response, operation|
+      c.another_lro_rpc(::Testing::NonstandardLroGrpc::AnotherRequest.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
@@ -214,33 +214,33 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, non_copy_another_lro_rpc_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.non_copy_another_lro_rpc({  }) do |response, operation|
+      c.non_copy_another_lro_rpc({  }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |response, operation|
+      c.non_copy_another_lro_rpc ::Testing::NonstandardLroGrpc::NonCopyRequest.new() do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.non_copy_another_lro_rpc({  }, grpc_options) do |response, operation|
+      c.non_copy_another_lro_rpc({  }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), grpc_options) do |response, operation|
+      c.non_copy_another_lro_rpc(::Testing::NonstandardLroGrpc::NonCopyRequest.new(), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
@@ -270,40 +270,40 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, aip_lro_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.aip_lro({ request_id: request_id }) do |response, operation|
+      c.aip_lro({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.aip_lro request_id: request_id do |response, operation|
+      c.aip_lro request_id: request_id do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      c.aip_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.aip_lro({ request_id: request_id }, grpc_options) do |response, operation|
+      c.aip_lro({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      c.aip_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -333,36 +333,36 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
 
     Gapic::ServiceStub.stub :new, no_lro_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.no_lro({ request_id: request_id }) do |response, operation|
+      c.no_lro({ request_id: request_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.no_lro request_id: request_id do |response, operation|
+      c.no_lro request_id: request_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      c.no_lro ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.no_lro({ request_id: request_id }, grpc_options) do |response, operation|
+      c.no_lro({ request_id: request_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      c.no_lro(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_rest_test.rb
@@ -106,32 +106,32 @@ class ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::ClientTest < Mini
     ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::ServiceStub.stub :transcode_get_another_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_another_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |_result, response|
+        client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |_result, response|
+        client_stub.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |_result, response|
+        client_stub.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, call_options) do |_result, response|
+        client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), call_options) do |_result, response|
+        client_stub.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_rest_test.rb
@@ -106,32 +106,32 @@ class ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::ClientTest < Mini
     ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::ServiceStub.stub :transcode_get_another_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_another_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |_result, response|
+        c.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |_result, response|
+        c.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |_result, response|
+        c.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, call_options) do |_result, response|
+        c.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), call_options) do |_result, response|
+        c.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
@@ -92,36 +92,36 @@ class ::Testing::NonstandardLroGrpc::AnotherLroProvider::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, get_another_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |response, operation|
+      c.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |response, operation|
+      c.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |response, operation|
+      c.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, grpc_options) do |response, operation|
+      c.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), grpc_options) do |response, operation|
+      c.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
@@ -92,36 +92,36 @@ class ::Testing::NonstandardLroGrpc::AnotherLroProvider::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, get_another_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::AnotherLroProvider::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |response, operation|
+      client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |response, operation|
+      client_stub.get_another another_request_id: another_request_id, another_lro_name: another_lro_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |response, operation|
+      client_stub.get_another ::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, grpc_options) do |response, operation|
+      client_stub.get_another({ another_request_id: another_request_id, another_lro_name: another_lro_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), grpc_options) do |response, operation|
+      client_stub.get_another(::Testing::NonstandardLroGrpc::LroAnotherGetRequest.new(another_request_id: another_request_id, another_lro_name: another_lro_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_rest_test.rb
@@ -105,32 +105,32 @@ class ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::ClientTest < Minite
     ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::ServiceStub.stub :transcode_plain_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_lro_rpc_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.plain_lro_rpc({ request_id: request_id }) do |_result, response|
+        client_stub.plain_lro_rpc({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.plain_lro_rpc request_id: request_id do |_result, response|
+        client_stub.plain_lro_rpc request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
+        client_stub.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_rest_test.rb
@@ -105,32 +105,32 @@ class ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::ClientTest < Minite
     ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::ServiceStub.stub :transcode_plain_lro_rpc_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_lro_rpc_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.plain_lro_rpc({ request_id: request_id }) do |_result, response|
+        c.plain_lro_rpc({ request_id: request_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.plain_lro_rpc request_id: request_id do |_result, response|
+        c.plain_lro_rpc request_id: request_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
+        c.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
+        c.plain_lro_rpc({ request_id: request_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
+        c.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
@@ -90,40 +90,40 @@ class ::Testing::NonstandardLroGrpc::PlainLroConsumer::ClientTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, plain_lro_rpc_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain_lro_rpc({ request_id: request_id }) do |response, operation|
+      client_stub.plain_lro_rpc({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain_lro_rpc request_id: request_id do |response, operation|
+      client_stub.plain_lro_rpc request_id: request_id do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
+      client_stub.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
@@ -90,40 +90,40 @@ class ::Testing::NonstandardLroGrpc::PlainLroConsumer::ClientTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, plain_lro_rpc_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::PlainLroConsumer::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain_lro_rpc({ request_id: request_id }) do |response, operation|
+      c.plain_lro_rpc({ request_id: request_id }) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain_lro_rpc request_id: request_id do |response, operation|
+      c.plain_lro_rpc request_id: request_id do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
+      c.plain_lro_rpc ::Testing::NonstandardLroGrpc::Request.new(request_id: request_id) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
+      c.plain_lro_rpc({ request_id: request_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
+      c.plain_lro_rpc(::Testing::NonstandardLroGrpc::Request.new(request_id: request_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::GenericLRO::Operation, response
         assert_equal grpc_response, response.operation
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_rest_test.rb
@@ -106,32 +106,32 @@ class ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::ClientTest < Minite
     ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client_stub = ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::Client.new do |config|
+        c = ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |_result, response|
+        c.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.get initial_request_id: initial_request_id, lro_name: lro_name do |_result, response|
+        c.get initial_request_id: initial_request_id, lro_name: lro_name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |_result, response|
+        c.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }, call_options) do |_result, response|
+        c.get({ initial_request_id: initial_request_id, lro_name: lro_name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), call_options) do |_result, response|
+        c.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_rest_test.rb
@@ -106,32 +106,32 @@ class ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::ClientTest < Minite
     ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::ServiceStub.stub :transcode_get_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_client_stub do
         # Create client
-        client = ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::Client.new do |config|
+        client_stub = ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |_result, response|
+        client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get initial_request_id: initial_request_id, lro_name: lro_name do |_result, response|
+        client_stub.get initial_request_id: initial_request_id, lro_name: lro_name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |_result, response|
+        client_stub.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get({ initial_request_id: initial_request_id, lro_name: lro_name }, call_options) do |_result, response|
+        client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), call_options) do |_result, response|
+        client_stub.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
@@ -92,36 +92,36 @@ class ::Testing::NonstandardLroGrpc::PlainLroProvider::ClientTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, get_client_stub do
       # Create client
-      client = ::Testing::NonstandardLroGrpc::PlainLroProvider::Client.new do |config|
+      client_stub = ::Testing::NonstandardLroGrpc::PlainLroProvider::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |response, operation|
+      client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get initial_request_id: initial_request_id, lro_name: lro_name do |response, operation|
+      client_stub.get initial_request_id: initial_request_id, lro_name: lro_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |response, operation|
+      client_stub.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get({ initial_request_id: initial_request_id, lro_name: lro_name }, grpc_options) do |response, operation|
+      client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), grpc_options) do |response, operation|
+      client_stub.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
@@ -92,36 +92,36 @@ class ::Testing::NonstandardLroGrpc::PlainLroProvider::ClientTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, get_client_stub do
       # Create client
-      client_stub = ::Testing::NonstandardLroGrpc::PlainLroProvider::Client.new do |config|
+      c = ::Testing::NonstandardLroGrpc::PlainLroProvider::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |response, operation|
+      c.get({ initial_request_id: initial_request_id, lro_name: lro_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.get initial_request_id: initial_request_id, lro_name: lro_name do |response, operation|
+      c.get initial_request_id: initial_request_id, lro_name: lro_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |response, operation|
+      c.get ::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.get({ initial_request_id: initial_request_id, lro_name: lro_name }, grpc_options) do |response, operation|
+      c.get({ initial_request_id: initial_request_id, lro_name: lro_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), grpc_options) do |response, operation|
+      c.get(::Testing::NonstandardLroGrpc::LroGetRequest.new(initial_request_id: initial_request_id, lro_name: lro_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/resources/service_resources_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/resources/service_resources_test.rb
@@ -90,36 +90,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, plain_client_stub do
       # Create client
-      client = ::Testing::Resources::ServiceResources::Client.new do |config|
+      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain({ resource_name: resource_name }) do |response, operation|
+      client_stub.plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain resource_name: resource_name do |response, operation|
+      client_stub.plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain ::Testing::Resources::RequestResource.new(resource_name: resource_name) do |response, operation|
+      client_stub.plain ::Testing::Resources::RequestResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      client_stub.plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain(::Testing::Resources::RequestResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      client_stub.plain(::Testing::Resources::RequestResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, another_plain_client_stub do
       # Create client
-      client = ::Testing::Resources::ServiceResources::Client.new do |config|
+      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.another_plain({ resource_name: resource_name }) do |response, operation|
+      client_stub.another_plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.another_plain resource_name: resource_name do |response, operation|
+      client_stub.another_plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.another_plain ::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name) do |response, operation|
+      client_stub.another_plain ::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.another_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      client_stub.another_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.another_plain(::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      client_stub.another_plain(::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -206,36 +206,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, third_plain_client_stub do
       # Create client
-      client = ::Testing::Resources::ServiceResources::Client.new do |config|
+      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.third_plain({ resource_name: resource_name }) do |response, operation|
+      client_stub.third_plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.third_plain resource_name: resource_name do |response, operation|
+      client_stub.third_plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.third_plain ::Testing::Resources::RequestThirdResource.new(resource_name: resource_name) do |response, operation|
+      client_stub.third_plain ::Testing::Resources::RequestThirdResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.third_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      client_stub.third_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.third_plain(::Testing::Resources::RequestThirdResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      client_stub.third_plain(::Testing::Resources::RequestThirdResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, fourth_plain_client_stub do
       # Create client
-      client = ::Testing::Resources::ServiceResources::Client.new do |config|
+      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.fourth_plain({ resource_name: resource_name }) do |response, operation|
+      client_stub.fourth_plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.fourth_plain resource_name: resource_name do |response, operation|
+      client_stub.fourth_plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.fourth_plain ::Testing::Resources::RequestFourthResource.new(resource_name: resource_name) do |response, operation|
+      client_stub.fourth_plain ::Testing::Resources::RequestFourthResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.fourth_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      client_stub.fourth_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.fourth_plain(::Testing::Resources::RequestFourthResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      client_stub.fourth_plain(::Testing::Resources::RequestFourthResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/resources/service_resources_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/resources/service_resources_test.rb
@@ -90,36 +90,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, plain_client_stub do
       # Create client
-      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
+      c = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain({ resource_name: resource_name }) do |response, operation|
+      c.plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain resource_name: resource_name do |response, operation|
+      c.plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain ::Testing::Resources::RequestResource.new(resource_name: resource_name) do |response, operation|
+      c.plain ::Testing::Resources::RequestResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      c.plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain(::Testing::Resources::RequestResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      c.plain(::Testing::Resources::RequestResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, another_plain_client_stub do
       # Create client
-      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
+      c = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.another_plain({ resource_name: resource_name }) do |response, operation|
+      c.another_plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.another_plain resource_name: resource_name do |response, operation|
+      c.another_plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.another_plain ::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name) do |response, operation|
+      c.another_plain ::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.another_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      c.another_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.another_plain(::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      c.another_plain(::Testing::Resources::RequestAnotherResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -206,36 +206,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, third_plain_client_stub do
       # Create client
-      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
+      c = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.third_plain({ resource_name: resource_name }) do |response, operation|
+      c.third_plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.third_plain resource_name: resource_name do |response, operation|
+      c.third_plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.third_plain ::Testing::Resources::RequestThirdResource.new(resource_name: resource_name) do |response, operation|
+      c.third_plain ::Testing::Resources::RequestThirdResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.third_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      c.third_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.third_plain(::Testing::Resources::RequestThirdResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      c.third_plain(::Testing::Resources::RequestThirdResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -264,36 +264,36 @@ class ::Testing::Resources::ServiceResources::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, fourth_plain_client_stub do
       # Create client
-      client_stub = ::Testing::Resources::ServiceResources::Client.new do |config|
+      c = ::Testing::Resources::ServiceResources::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.fourth_plain({ resource_name: resource_name }) do |response, operation|
+      c.fourth_plain({ resource_name: resource_name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.fourth_plain resource_name: resource_name do |response, operation|
+      c.fourth_plain resource_name: resource_name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.fourth_plain ::Testing::Resources::RequestFourthResource.new(resource_name: resource_name) do |response, operation|
+      c.fourth_plain ::Testing::Resources::RequestFourthResource.new(resource_name: resource_name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.fourth_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
+      c.fourth_plain({ resource_name: resource_name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.fourth_plain(::Testing::Resources::RequestFourthResource.new(resource_name: resource_name), grpc_options) do |response, operation|
+      c.fourth_plain(::Testing::Resources::RequestFourthResource.new(resource_name: resource_name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_rest_test.rb
@@ -107,32 +107,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_plain_no_template_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_no_template_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -163,32 +163,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_plain_full_field_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_full_field_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -219,32 +219,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_plain_extract_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_extract_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -275,32 +275,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_complex_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, complex_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -331,32 +331,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_with_sub_message_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, with_sub_message_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_rest_test.rb
@@ -107,32 +107,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_plain_no_template_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_no_template_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -163,32 +163,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_plain_full_field_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_full_field_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -219,32 +219,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_plain_extract_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_extract_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -275,32 +275,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_complex_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, complex_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -331,32 +331,32 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ServiceStub.stub :transcode_with_sub_message_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, with_sub_message_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
@@ -94,36 +94,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_no_template_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -156,36 +156,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_full_field_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -218,36 +218,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_extract_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -280,36 +280,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, complex_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -342,36 +342,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, with_sub_message_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
@@ -94,36 +94,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_no_template_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.plain_no_template table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.plain_no_template ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.plain_no_template({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.plain_no_template(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -156,36 +156,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_full_field_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.plain_full_field table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.plain_full_field ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.plain_full_field({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.plain_full_field(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -218,36 +218,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_extract_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.plain_extract table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.plain_extract ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.plain_extract({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.plain_extract(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -280,36 +280,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, complex_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.complex table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.complex ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.complex({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.complex(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -342,36 +342,36 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, with_sub_message_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_rest_test.rb
@@ -107,32 +107,32 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ServiceStub.stub :transcode_plain_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -163,32 +163,32 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ServiceStub.stub :transcode_with_sub_message_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, with_sub_message_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -219,32 +219,32 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ServiceStub.stub :transcode_with_multiple_levels_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, with_multiple_levels_client_stub do
         # Create client
-        client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
+        c = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        c.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client_stub.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        c.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client_stub.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        c.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        c.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client_stub.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        c.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_rest_test.rb
@@ -107,32 +107,32 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ServiceStub.stub :transcode_plain_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, plain_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -163,32 +163,32 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ServiceStub.stub :transcode_with_sub_message_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, with_sub_message_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -219,32 +219,32 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ClientTest < Mini
     ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ServiceStub.stub :transcode_with_multiple_levels_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, with_multiple_levels_client_stub do
         # Create client
-        client = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
+        client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
+        client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
+        client_stub.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
+        client_stub.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
+        client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
+        client_stub.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
@@ -94,36 +94,36 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -156,36 +156,36 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, with_sub_message_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -218,36 +218,36 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, with_multiple_levels_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
@@ -94,36 +94,36 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, plain_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -156,36 +156,36 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, with_sub_message_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.with_sub_message table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.with_sub_message ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.with_sub_message({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.with_sub_message(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -218,36 +218,36 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::
 
     Gapic::ServiceStub.stub :new, with_multiple_levels_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.with_multiple_levels table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.with_multiple_levels ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.with_multiple_levels({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.with_multiple_levels(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
@@ -94,36 +94,36 @@ class ::Testing::RoutingHeaders::ServiceNoHeaders::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, plain_client_stub do
       # Create client
-      client = ::Testing::RoutingHeaders::ServiceNoHeaders::Client.new do |config|
+      client_stub = ::Testing::RoutingHeaders::ServiceNoHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      client_stub.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      client_stub.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      client_stub.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
@@ -94,36 +94,36 @@ class ::Testing::RoutingHeaders::ServiceNoHeaders::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, plain_client_stub do
       # Create client
-      client_stub = ::Testing::RoutingHeaders::ServiceNoHeaders::Client.new do |config|
+      c = ::Testing::RoutingHeaders::ServiceNoHeaders::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
+      c.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client_stub.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
+      c.plain table_name: table_name, app_profile_id: app_profile_id, resource: resource do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client_stub.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
+      c.plain ::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client_stub.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
+      c.plain({ table_name: table_name, app_profile_id: app_profile_id, resource: resource }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client_stub.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
+      c.plain(::Testing::RoutingHeaders::Request.new(table_name: table_name, app_profile_id: app_profile_id, resource: resource), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end


### PR DESCRIPTION
Renames the local `client` variable (used when instantiating the service client under test) to `client_stub` across all gRPC and REST test templates.

This prevents variable shadowing and collisions with existing names.

This fixes a generation error in `google-cloud-run-v2` where the gem introduces a field named `client` in [`SubmitBuildRequest`](https://github.com/googleapis/googleapis/blob/a0cedfb6af9305b49db07dccaa7d0c8985e07e70/google/cloud/run/v2/build.proto#L143).

Failed generation PR: https://github.com/googleapis/google-cloud-ruby/pull/32252