### PR TITLE
fix: prevent YARD failures on enum keywords

### DIFF
--- a/gapic-generator/lib/gapic/presenters/enum_value_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/enum_value_presenter.rb
@@ -28,7 +28,18 @@ module Gapic
 
       # @return [String] The enum value name without keyword collision.
       def name
-        Gapic::RubyInfo.keywords.include?(@value.name) ? "#{@value.parent.name}::#{@value.name}" : @value.name
+        keyword_collision? ? "#{@value.parent.name}::#{@value.name}" : @value.name
+      end
+
+      # @return [Boolean] Whether the enum name collides with a Ruby keyword.
+      def keyword_collision?
+        Gapic::RubyInfo.keywords.include? @value.name
+      end
+
+      # @return [String] The doc stub string for the enum value. Prevents YARD warnings in cases of keyword
+      # collision.
+      def doc_line
+        keyword_collision? ? "const_set :#{@value.name}, #{@value.number}" : "#{@value.name} = #{@value.number}"
       end
 
       def doc_description

--- a/gapic-generator/templates/default/proto_docs/_enum.text.erb
+++ b/gapic-generator/templates/default/proto_docs/_enum.text.erb
@@ -9,6 +9,6 @@ module <%= enum.name %>
   <%- if value.doc_description -%>
 <%= indent value.doc_description, "  # " %>
   <%- end -%>
-  <%= value.name %> = <%= value.number %>
+  <%= value.doc_line %>
   <%- end -%>
 end

--- a/gapic-generator/test/gapic/presenters/enum_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/enum_presenter_test.rb
@@ -29,5 +29,13 @@ class EnumValuePresenterTest < PresenterTest
   def test_enum_value_name_with_keyword_collision
     evp = typical_garbage_enum_value 4
     assert_equal "GarbageEnum::END", evp.name
+    assert evp.keyword_collision?
+    assert_equal "const_set :END, 4", evp.doc_line
+  end
+
+  def test_enum_value_doc_line_no_keyword_collision
+    evp = typical_garbage_enum_value 3
+    refute evp.keyword_collision?
+    assert_equal "DUMPSTER = 3", evp.doc_line
   end
 end

--- a/shared/output/gapic/templates/garbage/proto_docs/garbage/garbage.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/garbage/garbage.rb
@@ -477,7 +477,7 @@ module So
         DUMPSTER = 3
 
         # The end of garbage.
-        GarbageEnum::END = 4
+        const_set :END, 4
       end
     end
   end


### PR DESCRIPTION
I previously addressed these keyword collisions in PR #1061 and #1072.

However, the syntax still generates YARD proxy warnings that cause strict builds to fail (i.e. `fail-on-warning`), an issue observed during CI for `google-apps-card-v1`.

This update utilizes `const_set` to successfully bypass the warnings.

I verified directly on the gem via manual edits and running `toys yard`.

Related issue: https://github.com/googleapis/google-cloud-ruby/issues/34012