### PR TITLE
chore(ci): use yoshi bot to bypass tag creation restrictions

### DIFF
--- a/.github/workflows/tag-generators.yml
+++ b/.github/workflows/tag-generators.yml
@@ -14,13 +14,15 @@ jobs:
     if: ${{ github.repository == 'googleapis/gapic-generator-ruby' }}
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     permissions:
       contents: write
       packages: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       - name: Install Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The 'Tag Generator Release' workflow fails with a GH013 repository rule violation error:
`"remote: - Cannot create ref due to creations being restricted."`

The current workflow was configured to use the default `secrets.GITHUB_TOKEN`. This token doesn't have bypass permissions to create tags directly on the repository under the current repository rules.

This change better aligns with other configurations such as `.github/workflows/release-generators.yml` in this repo, or in [google-cloud-ruby](https://github.com/googleapis/google-cloud-ruby/blob/main/.github/workflows/new-library.yml#L15)

As a workaround, we were manually creating tags via AoD.

Fixes #1290