### PR TITLE
chore: Fix Lint/SafeNavigationWithEmpty RuboCop warnings

### DIFF
--- a/gapic-generator/lib/gapic/presenters/sample_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/sample_presenter.rb
@@ -69,7 +69,7 @@ module Gapic
           @value = convert field["value"]
           @input_parameter = field["input_parameter"]
           @comment = field["comment"]
-          @comment = nil if @comment&.empty?
+          @comment = nil if @comment && @comment.empty?
           @value_is_file = field["value_is_file"]
         end
 

--- a/gapic-generator/lib/gapic/presenters/snippet/parameter_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/parameter_presenter.rb
@@ -33,7 +33,7 @@ module Gapic
         def initialize proto, json
           @name = proto.name
           @description = proto.description
-          @description = nil if @description&.empty?
+          @description = nil if @description && @description.empty?
           @type = TypePresenter.new proto&.type, json&.fetch("type", nil)
           @example = ExpressionPresenter.new proto&.value, json&.fetch("value", nil)
         end


### PR DESCRIPTION
Noticed in https://github.com/googleapis/gapic-generator-ruby/pull/1301

Tested via `toys rubocop`

```
toys rubocop
Running rubocop in gapic-generator
Inspecting 100 files
....................................................................................................

100 files inspected, no offenses detected
Running rubocop in gapic-generator-ads
Inspecting 6 files
......

6 files inspected, no offenses detected
Running rubocop in gapic-generator-cloud
Inspecting 15 files
...............

15 files inspected, no offenses detected
```