### PR TITLE
chore: Update googleads build test target to v21

### DIFF
--- a/.kokoro/bazel-test.sh
+++ b/.kokoro/bazel-test.sh
@@ -42,7 +42,7 @@ cat generator-versions.json
 # try generating the google/example/library/v1 ruby gapic library
 bazelisk build //google/example/library/v1:google-cloud-example-library-v1-ruby
 
-# try generating the google/ads/googleads/v20 ruby gapic library
-bazelisk build //google/ads/googleads/v20:googleads-ruby
+# try generating the google/ads/googleads/v21 ruby gapic library
+bazelisk build //google/ads/googleads/v21:googleads-ruby
 
 popd


### PR DESCRIPTION
googleads v20 is deprecated causing the build to fail. Updating to a newer version.

Noticed in https://github.com/googleapis/gapic-generator-ruby/pull/1303