### PR TITLE
test: Add JUnit XML reporting to gapic-generator-ruby tests

### DIFF
--- a/gapic-generator-ads/Gemfile
+++ b/gapic-generator-ads/Gemfile
@@ -13,6 +13,7 @@ gem "grpc-tools", ">= 1.60.0", "< 1.75.1"
 gem "minitest", "~> 5.16"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.0"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "0.6.3"
 gem "pry", ">= 0.14"
 gem "redcarpet", "~> 3.0"

--- a/gapic-generator-ads/Gemfile.lock
+++ b/gapic-generator-ads/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    ansi (1.6.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (3.3.1)
@@ -85,6 +86,11 @@ GEM
       path_expander (~> 2.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-reporters (1.5.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     minitest-server (1.0.10)
       drb (~> 2.0)
       minitest (~> 5.16)
@@ -156,6 +162,7 @@ DEPENDENCIES
   minitest (~> 5.16)
   minitest-autotest (~> 1.0)
   minitest-focus (~> 1.0)
+  minitest-reporters (~> 1.5.0)
   ostruct (= 0.6.3)
   pry (>= 0.14)
   redcarpet (~> 3.0)

--- a/gapic-generator-ads/test/test_helper.rb
+++ b/gapic-generator-ads/test/test_helper.rb
@@ -20,6 +20,31 @@ require "gapic/schema/api"
 require "gapic/generators/ads_generator"
 require "gapic/presenters"
 
+# Configure JUnit XML test formatting for TestGrid build health and test failure tracking.
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  begin
+    require "fileutils"
+    FileUtils.mkdir_p "tmp/reports"
+    require "minitest/reporters"
+    unless defined? SpongeReporter
+      class SpongeReporter < Minitest::Reporters::JUnitReporter
+        private
+        # Override the default reporter filename format (TEST-minitest.xml) to write
+        # directly to sponge_log.xml as required by Kokoro/Sponge telemetry collection.
+        def filename_for suite
+          File.join @reports_path, "sponge_log.xml"
+        end
+      end
+    end
+    Minitest::Reporters.use! [
+      Minitest::Reporters::SpecReporter.new,
+      SpongeReporter.new("tmp/reports", false, { single_file: true })
+    ]
+  rescue LoadError
+    # Fallback if minitest-reporters is not installed in the bundle.
+  end
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 

--- a/gapic-generator-cloud/Gemfile
+++ b/gapic-generator-cloud/Gemfile
@@ -13,6 +13,7 @@ gem "grpc-tools", ">= 1.60.0", "< 1.75.1"
 gem "minitest", "~> 5.16"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.0"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "0.6.3"
 gem "pry", ">= 0.14"
 gem "redcarpet", "~> 3.0"

--- a/gapic-generator-cloud/Gemfile.lock
+++ b/gapic-generator-cloud/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    ansi (1.6.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (3.3.1)
@@ -85,6 +86,11 @@ GEM
       path_expander (~> 2.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-reporters (1.5.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     minitest-server (1.0.10)
       drb (~> 2.0)
       minitest (~> 5.16)
@@ -156,6 +162,7 @@ DEPENDENCIES
   minitest (~> 5.16)
   minitest-autotest (~> 1.0)
   minitest-focus (~> 1.0)
+  minitest-reporters (~> 1.5.0)
   ostruct (= 0.6.3)
   pry (>= 0.14)
   redcarpet (~> 3.0)

--- a/gapic-generator-cloud/test/test_helper.rb
+++ b/gapic-generator-cloud/test/test_helper.rb
@@ -23,6 +23,31 @@ require "gapic/generators/cloud_generator"
 require "action_controller"
 require "action_view"
 
+# Configure JUnit XML test formatting for TestGrid build health and test failure tracking.
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  begin
+    require "fileutils"
+    FileUtils.mkdir_p "tmp/reports"
+    require "minitest/reporters"
+    unless defined? SpongeReporter
+      class SpongeReporter < Minitest::Reporters::JUnitReporter
+        private
+        # Override the default reporter filename format (TEST-minitest.xml) to write
+        # directly to sponge_log.xml as required by Kokoro/Sponge telemetry collection.
+        def filename_for suite
+          File.join @reports_path, "sponge_log.xml"
+        end
+      end
+    end
+    Minitest::Reporters.use! [
+      Minitest::Reporters::SpecReporter.new,
+      SpongeReporter.new("tmp/reports", false, { single_file: true })
+    ]
+  rescue LoadError
+    # Fallback if minitest-reporters is not installed in the bundle.
+  end
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "ostruct"

--- a/gapic-generator/Gemfile
+++ b/gapic-generator/Gemfile
@@ -11,6 +11,7 @@ gem "grpc-tools", ">= 1.60.0", "< 1.75.1"
 gem "minitest", "~> 5.16"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.0"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "0.6.3"
 gem "pry", ">= 0.14"
 gem "redcarpet", "~> 3.0"

--- a/gapic-generator/Gemfile.lock
+++ b/gapic-generator/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    ansi (1.6.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (3.3.1)
@@ -79,6 +80,11 @@ GEM
       path_expander (~> 2.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-reporters (1.5.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     minitest-server (1.0.10)
       drb (~> 2.0)
       minitest (~> 5.16)
@@ -149,6 +155,7 @@ DEPENDENCIES
   minitest (~> 5.16)
   minitest-autotest (~> 1.0)
   minitest-focus (~> 1.0)
+  minitest-reporters (~> 1.5.0)
   ostruct (= 0.6.3)
   pry (>= 0.14)
   redcarpet (~> 3.0)

--- a/gapic-generator/test/test_helper.rb
+++ b/gapic-generator/test/test_helper.rb
@@ -28,6 +28,31 @@ require "action_controller"
 require "action_view"
 require "ostruct"
 
+# Configure JUnit XML test formatting for TestGrid build health and test failure tracking.
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  begin
+    require "fileutils"
+    FileUtils.mkdir_p "tmp/reports"
+    require "minitest/reporters"
+    unless defined? SpongeReporter
+      class SpongeReporter < Minitest::Reporters::JUnitReporter
+        private
+        # Override the default reporter filename format (TEST-minitest.xml) to write
+        # directly to sponge_log.xml as required by Kokoro/Sponge telemetry collection.
+        def filename_for suite
+          File.join @reports_path, "sponge_log.xml"
+        end
+      end
+    end
+    Minitest::Reporters.use! [
+      Minitest::Reporters::SpecReporter.new,
+      SpongeReporter.new("tmp/reports", false, { single_file: true })
+    ]
+  rescue LoadError
+    # Fallback if minitest-reporters is not installed in the bundle.
+  end
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 


### PR DESCRIPTION
Write minitest execution output to JUnit XML reports. This enables centralized test result indexing, flake tracing, and build health metrics reporting inside TestGrid dashboards.