### PR TITLE
fix(gapic-generator): Indent note in the Config#credentials attribute properly

### DIFF
--- a/gapic-generator/templates/default/service/client/_config.text.erb
+++ b/gapic-generator/templates/default/service/client/_config.text.erb
@@ -65,11 +65,11 @@
 #     end
 #
 #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-#   external source for authentication to Google Cloud, you must validate it before
-#   providing it to a Google API client library. Providing an unvalidated credential
-#   configuration to Google APIs can compromise the security of your systems and data.
-#   For more information, refer to [Validate credential configurations from external
-#   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+#     external source for authentication to Google Cloud, you must validate it before
+#     providing it to a Google API client library. Providing an unvalidated credential
+#     configuration to Google APIs can compromise the security of your systems and data.
+#     For more information, refer to [Validate credential configurations from external
+#     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
 #   @return [::Object]
 # @!attribute [rw] scope
 #   The OAuth scopes
@@ -185,7 +185,7 @@ class Configuration
   #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
   #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
   #         trigger a retry.
-  # 
+  #
   class Rpcs
   <%- method_service.methods.each do |method| -%>
     ##

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v19/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v19/services/campaign_service/client.rb
@@ -478,11 +478,11 @@ module Google
               #     end
               #
               #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-              #   external source for authentication to Google Cloud, you must validate it before
-              #   providing it to a Google API client library. Providing an unvalidated credential
-              #   configuration to Google APIs can compromise the security of your systems and data.
-              #   For more information, refer to [Validate credential configurations from external
-              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+              #     external source for authentication to Google Cloud, you must validate it before
+              #     providing it to a Google API client library. Providing an unvalidated credential
+              #     configuration to Google APIs can compromise the security of your systems and data.
+              #     For more information, refer to [Validate credential configurations from external
+              #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
+++ b/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
@@ -1512,11 +1512,11 @@ module Grafeas
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -1307,11 +1307,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -569,11 +569,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -808,11 +808,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
+++ b/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
@@ -427,11 +427,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -1652,11 +1652,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/adaptation/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/adaptation/client.rb
@@ -1249,11 +1249,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -516,11 +516,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -670,11 +670,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -706,11 +706,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -670,11 +670,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -2211,11 +2211,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -670,11 +670,11 @@ module Google
             #     end
             #
             #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-            #   external source for authentication to Google Cloud, you must validate it before
-            #   providing it to a Google API client library. Providing an unvalidated credential
-            #   configuration to Google APIs can compromise the security of your systems and data.
-            #   For more information, refer to [Validate credential configurations from external
-            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+            #     external source for authentication to Google Cloud, you must validate it before
+            #     providing it to a Google API client library. Providing an unvalidated credential
+            #     configuration to Google APIs can compromise the security of your systems and data.
+            #     For more information, refer to [Validate credential configurations from external
+            #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service/client.rb
@@ -308,11 +308,11 @@ module So
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -1761,11 +1761,11 @@ module So
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -668,11 +668,11 @@ module So
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
@@ -549,11 +549,11 @@ module So
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
@@ -308,11 +308,11 @@ module So
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
@@ -610,11 +610,11 @@ module So
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/client.rb
@@ -1195,11 +1195,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -1293,11 +1293,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -660,11 +660,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -690,11 +690,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -1496,11 +1496,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -660,11 +660,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/client.rb
@@ -763,11 +763,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -967,11 +967,11 @@ module Google
           #     end
           #
           #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-          #   external source for authentication to Google Cloud, you must validate it before
-          #   providing it to a Google API client library. Providing an unvalidated credential
-          #   configuration to Google APIs can compromise the security of your systems and data.
-          #   For more information, refer to [Validate credential configurations from external
-          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+          #     external source for authentication to Google Cloud, you must validate it before
+          #     providing it to a Google API client library. Providing an unvalidated credential
+          #     configuration to Google APIs can compromise the security of your systems and data.
+          #     For more information, refer to [Validate credential configurations from external
+          #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -321,11 +321,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -398,11 +398,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/client.rb
@@ -321,11 +321,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/client.rb
@@ -413,11 +413,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/operations.rb
@@ -659,11 +659,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
@@ -700,11 +700,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
@@ -659,11 +659,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/client.rb
@@ -329,11 +329,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/client.rb
@@ -352,11 +352,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/client.rb
@@ -329,11 +329,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/resources/service_resources/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/resources/service_resources/client.rb
@@ -546,11 +546,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/client.rb
@@ -748,11 +748,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/client.rb
@@ -530,11 +530,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_no_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_no_headers/client.rb
@@ -339,11 +339,11 @@ module Testing
         #     end
         #
         #   @note Warning: If you accept a credential configuration (JSON file or Hash) from an
-        #   external source for authentication to Google Cloud, you must validate it before
-        #   providing it to a Google API client library. Providing an unvalidated credential
-        #   configuration to Google APIs can compromise the security of your systems and data.
-        #   For more information, refer to [Validate credential configurations from external
-        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
+        #     external source for authentication to Google Cloud, you must validate it before
+        #     providing it to a Google API client library. Providing an unvalidated credential
+        #     configuration to Google APIs can compromise the security of your systems and data.
+        #     For more information, refer to [Validate credential configurations from external
+        #     sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes


### PR DESCRIPTION
Fixes the indentation on a multi-line `@note` yard tag. Without proper indentation, only the first line gets included in the note, while the remaining lines are orphaned into the general description of the method. (For an example of what this looks like, see https://rubydoc.info/gems/google-cloud-secret_manager-v1/Google/Cloud/SecretManager/V1/SecretManagerService/Client/Configuration#credentials-instance_method — the second warning note on the credentials method is cut off mid-sentence, and the remainder of the note appears below just above the examples.)

I found this as I was using secret_manager-v1 as a test case in a YARD plugin I'm working on.

Hope y'all are doing well!
