### PR TITLE
feat: remove Gemfile.lock from generated gem gitignore templates to enable tracking for Renovate

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/gitignore.text.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/gitignore.text.erb
@@ -1,6 +1,4 @@
 <%- assert_locals gem -%>
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/gapic-generator/gem_templates/gitignore.text.erb
+++ b/gapic-generator/gem_templates/gitignore.text.erb
@@ -1,4 +1,3 @@
-Gemfile.lock
 .DS_STORE
 /.bundle/
 /.yardoc

--- a/gapic-generator/templates/default/gem/gitignore.text.erb
+++ b/gapic-generator/templates/default/gem/gitignore.text.erb
@@ -1,6 +1,4 @@
 <%- assert_locals gem -%>
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/compute_small/.gitignore
+++ b/shared/output/cloud/compute_small/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/compute_small_wrapper/.gitignore
+++ b/shared/output/cloud/compute_small_wrapper/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/grafeas_v1/.gitignore
+++ b/shared/output/cloud/grafeas_v1/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/language_v1/.gitignore
+++ b/shared/output/cloud/language_v1/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/language_v1beta1/.gitignore
+++ b/shared/output/cloud/language_v1beta1/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/language_v1beta2/.gitignore
+++ b/shared/output/cloud/language_v1beta2/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/language_wrapper/.gitignore
+++ b/shared/output/cloud/language_wrapper/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/location/.gitignore
+++ b/shared/output/cloud/location/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/noservice_cloud/.gitignore
+++ b/shared/output/cloud/noservice_cloud/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/secretmanager_v1beta1/.gitignore
+++ b/shared/output/cloud/secretmanager_v1beta1/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/secretmanager_wrapper/.gitignore
+++ b/shared/output/cloud/secretmanager_wrapper/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/speech_v1/.gitignore
+++ b/shared/output/cloud/speech_v1/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/cloud/vision_v1/.gitignore
+++ b/shared/output/cloud/vision_v1/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/gapic/gems/my_plugin/.gitignore
+++ b/shared/output/gapic/gems/my_plugin/.gitignore
@@ -1,4 +1,3 @@
-Gemfile.lock
 .DS_STORE
 /.bundle/
 /.yardoc

--- a/shared/output/gapic/templates/garbage/.gitignore
+++ b/shared/output/gapic/templates/garbage/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/gapic/templates/noservice/.gitignore
+++ b/shared/output/gapic/templates/noservice/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/gapic/templates/showcase/.gitignore
+++ b/shared/output/gapic/templates/showcase/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output

--- a/shared/output/gapic/templates/testing/.gitignore
+++ b/shared/output/gapic/templates/testing/.gitignore
@@ -1,5 +1,3 @@
-# Ignore bundler lockfiles
-Gemfile.lock
 gems.locked
 
 # Ignore documentation output


### PR DESCRIPTION
## Overview

Removes `Gemfile.lock` from `.gitignore` ERB templates in `gapic-generator-ruby` so that generated Ruby client libraries track their `Gemfile.lock` files by default.

## Generation Flow & Scaffolding Architecture

1. **Gemfile Template Rendering**:
   - `gapic-generator-ruby` renders `Gemfile` using ERB templates (`gapic-generator/templates/default/gem/gemfile.text.erb` and `gapic-generator-cloud/templates/cloud/wrapper_gem/gemfile.text.erb`).
2. **Gitignore Template Rendering**:
   - The generator renders `.gitignore` using `gitignore.text.erb`. By removing `Gemfile.lock` from these templates, `Gemfile.lock` is no longer ignored by git.
3. **Lockfile Scaffolding (`bundle lock`)**:
   - As lockfiles contain exact resolved dependency trees from rubygems.org, `Gemfile.lock` is scaffolded by running `bundle lock` (or `bundle lock --update`) in the gem directory right after file rendering.
   - For automated client library regeneration in `google-cloud-ruby`, OwlBot executes `bundle lock` during post-processing (`.OwlBot-post-processor.rb` / OwlBot container), ensuring every regenerated library automatically commits a clean, tracked `Gemfile.lock` in its OwlBot PR.