### PR TITLE
feat: prefer documentation.summary over overview for gemspec description

### DIFF
--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -122,7 +122,11 @@ module Gapic
       end
 
       def gemspec_description
-        description.gsub(/\s+/, " ").strip
+        desc = gem_config(:description) ||
+               @api.api_metadata.summary ||
+               @api.api_metadata.description ||
+               "#{name} is the official client library for the #{title} API."
+        desc.gsub(/\s+/, " ").strip
       end
 
       ##


### PR DESCRIPTION
For https://github.com/googleapis/librarian/issues/7104

When generating Ruby gems, GAPIC Generator Ruby's `gemspec_description` currently uses `api_metadata.description` (which is populated from `documentation.overview` in `service.yaml`).

Because `documentation.overview` in `service.yaml` often starts with Markdown headers (e.g., `# Cloud Asset API`), `gemspec_description` replaces newlines with spaces and produces descriptions starting with strange leading `# ` headers.

This change updates `gemspec_description` in `GemPresenter` to prefer `api_metadata.summary` (`documentation.summary` from `service.yaml`) if present before falling back to `api_metadata.description`.