### PR TITLE
feat: Update protobuf to 33.2

### DIFF
--- a/gapic-generator-ads/Gemfile.lock
+++ b/gapic-generator-ads/Gemfile.lock
@@ -18,9 +18,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (8.1.3)
-      actionview (= 8.1.3)
-      activesupport (= 8.1.3)
+    actionpack (8.1.3.1)
+      actionview (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -28,13 +28,13 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actionview (8.1.3)
-      activesupport (= 8.1.3)
+    actionview (8.1.3.1)
+      activesupport (= 8.1.3.1)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (8.1.3)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -53,7 +53,7 @@ GEM
     bigdecimal (3.3.1)
     builder (3.3.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
     drb (2.2.3)
@@ -76,7 +76,7 @@ GEM
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
@@ -98,7 +98,7 @@ GEM
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (2.1.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     path_expander (2.0.1)
@@ -118,8 +118,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.4.2)
@@ -150,7 +150,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    yard (0.9.44)
+    yard (0.9.45)
 
 PLATFORMS
   x86_64-linux

--- a/gapic-generator-ads/Gemfile.lock
+++ b/gapic-generator-ads/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (~> 8.0)
       bigdecimal (~> 3.0)
       google-cloud-common (~> 1.2)
-      google-protobuf (~> 4.30)
+      google-protobuf (~> 4.32)
       google-style (~> 1.32.0)
       googleapis-common-protos-types (~> 1.9)
 
@@ -72,7 +72,7 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/gapic-generator-cloud/Gemfile.lock
+++ b/gapic-generator-cloud/Gemfile.lock
@@ -18,9 +18,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (8.1.3)
-      actionview (= 8.1.3)
-      activesupport (= 8.1.3)
+    actionpack (8.1.3.1)
+      actionview (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -28,13 +28,13 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actionview (8.1.3)
-      activesupport (= 8.1.3)
+    actionview (8.1.3.1)
+      activesupport (= 8.1.3.1)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (8.1.3)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -53,7 +53,7 @@ GEM
     bigdecimal (3.3.1)
     builder (3.3.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
     drb (2.2.3)
@@ -76,7 +76,7 @@ GEM
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
@@ -98,7 +98,7 @@ GEM
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (2.1.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     path_expander (2.0.1)
@@ -118,8 +118,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.4.2)
@@ -150,7 +150,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    yard (0.9.44)
+    yard (0.9.45)
 
 PLATFORMS
   x86_64-linux

--- a/gapic-generator-cloud/Gemfile.lock
+++ b/gapic-generator-cloud/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (~> 8.0)
       bigdecimal (~> 3.0)
       google-cloud-common (~> 1.2)
-      google-protobuf (~> 4.30)
+      google-protobuf (~> 4.32)
       google-style (~> 1.32.0)
       googleapis-common-protos-types (~> 1.9)
 
@@ -72,7 +72,7 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/gapic-generator/Gemfile.lock
+++ b/gapic-generator/Gemfile.lock
@@ -12,9 +12,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (8.1.3)
-      actionview (= 8.1.3)
-      activesupport (= 8.1.3)
+    actionpack (8.1.3.1)
+      actionview (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -22,13 +22,13 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actionview (8.1.3)
-      activesupport (= 8.1.3)
+    actionview (8.1.3.1)
+      activesupport (= 8.1.3.1)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (8.1.3)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -47,7 +47,7 @@ GEM
     bigdecimal (3.3.1)
     builder (3.3.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
     drb (2.2.3)
@@ -70,7 +70,7 @@ GEM
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
@@ -92,7 +92,7 @@ GEM
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (2.1.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     path_expander (2.0.1)
@@ -112,8 +112,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.4.2)
@@ -144,7 +144,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    yard (0.9.44)
+    yard (0.9.45)
 
 PLATFORMS
   x86_64-linux

--- a/gapic-generator/Gemfile.lock
+++ b/gapic-generator/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (~> 8.0)
       bigdecimal (~> 3.0)
       google-cloud-common (~> 1.2)
-      google-protobuf (~> 4.30)
+      google-protobuf (~> 4.32)
       google-style (~> 1.32.0)
       googleapis-common-protos-types (~> 1.9)
 
@@ -66,7 +66,7 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/gapic-generator/gapic-generator.gemspec
+++ b/gapic-generator/gapic-generator.gemspec
@@ -44,6 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bigdecimal", "~> 3.0"
   spec.add_dependency "googleapis-common-protos-types", "~> 1.9"
   spec.add_dependency "google-cloud-common", "~> 1.2"
-  spec.add_dependency "google-protobuf", "~> 4.30"
+  spec.add_dependency "google-protobuf", "~> 4.32"
   spec.add_dependency "google-style", "~> 1.32.0"
 end

--- a/rules_ruby_gapic/repositories.bzl
+++ b/rules_ruby_gapic/repositories.bzl
@@ -34,7 +34,7 @@ def gapic_generator_ruby_repositories():
 # list_of_gems: a dictionary of gem name -> version strings to be loaded when the ruby_runtime dependency builds
 #
 def gapic_generator_ruby_customgems(list_of_gems):
-  _protobuf_version = "3.25.6"
+  _protobuf_version = "33.2"
   _protobuf_version_in_link = "v%s" % _protobuf_version
   _maybe(
     http_archive,


### PR DESCRIPTION
1. Bump `_protobuf_version` to `33.2` in `rules_ruby_gapic/repositories.bzl` in preparation for Librarian onboarding.
