### PR TITLE
chore: bump gapic-showcase version in test harness to 0.44.0

### DIFF
--- a/shared/test/showcase/test_helper.rb
+++ b/shared/test/showcase/test_helper.rb
@@ -21,7 +21,7 @@ require "open3"
 require "tmpdir"
 
 # @private
-GAPIC_SHOWCASE_VERSION = '0.37.0'
+GAPIC_SHOWCASE_VERSION = '0.42.0'
 
 def generate_library_for_test imports, protos
   client_lib = Dir.mktmpdir


### PR DESCRIPTION
Bumps `GAPIC_SHOWCASE_VERSION` in `shared/test/showcase/test_helper.rb` from `0.37.0` to `0.44.0`.

### Why 0.44.0 and not 0.42.0
Two Showcase capabilities are needed to validate post-quantum key exchange from Ruby, and they landed in different releases:

| Capability | Showcase release | Needed for |
| :--- | :--- | :--- |
| PQC TLS support + `x-showcase-tls-group` reflection | `0.41.0` | Asserting the negotiated key exchange group |
| `--tls-groups` (restrict server to explicit IANA codepoints) | `0.43.0` | Exercising classical fallback and strict PQC pinning |

`0.42.0` predates `--tls-groups`, so it cannot drive the fallback scenarios. `0.44.0` is the current latest release.

### Scope
Test harness only. `shared/test/showcase/test_helper.rb` is not packaged into `gapic-generator`, `gapic-generator-cloud`, or `gapic-generator-ads`, and no generated output changes, so this is typed `chore:` and intentionally does not trigger a `release-please` publication.

### Stack

This is a **stacked PR**. Each branch targets its predecessor, so the diff here contains only the commits unique to this step. Review and merge bottom-up.

| # | PR | Branch → Base | Type | Scope |
| :-- | :-- | :-- | :-- | :-- |
| 1 | **#1330 ← this PR** | `bump-showcase` → `main` | `chore:` | Bump `GAPIC_SHOWCASE_VERSION` to `0.44.0` |
| 2 | #1331 | `pqc-tls-validation` → `bump-showcase` | `test:` | TLS harness: Showcase-generated certificates, CA-aware client factories |
| 3 | #1351 | `pqc-validation-tests` → `pqc-tls-validation` | `test:` | Net-new `pqc_test.rb`; tolerant REST assertion (Layer 1) |
| 4 | #1352 | `pqc-rest-ci` → `pqc-validation-tests` | `chore(ci):` | Strict REST PQC job on an OpenSSL 3.5 image (Layer 2) |

**Companion PR** — independent, different repository, *not* part of this stack:
[googleapis/ruby-core-libraries#73](https://github.com/googleapis/ruby-core-libraries/pull/73) — `fix:` raise the `gapic-common` floor to `grpc ">= 1.83", "< 2.a"`. This is the only customer-facing change in the effort and the only one that triggers a gem release.

Design: [go/sdk:ruby-pqc](https://docs.google.com/document/d/14K4GCKL8xA6ldKJj8to0_qtnk60LI8R9eUUw2jo-dvQ/edit) · Parent (approved): [go/cloudsdk-pqc-ruby](http://goto.google.com/cloudsdk-pqc-ruby)

### Pre-Flight Engineering Audit Sign-Off
- [x] **Encapsulation** — no accessors added; no production code touched.
- [x] **Concurrency clarity** — no threading primitives introduced.
- [x] **Test brittleness** — no stubbing; single constant change.
- [x] **DRY** — version is referenced through the existing single constant.
- [x] **Native multi-version matrix** — `toys test showcase` green on Ruby 4.0.5 and 3.2.11 (60 runs, 300 assertions, 0 failures).
- [x] **Lockfile hygiene** — `git diff origin/main` touches only `test_helper.rb`.


