### PR TITLE
test: update googleads bazel test target to v25 in kokoro

### DIFF
--- a/.kokoro/bazel-test.sh
+++ b/.kokoro/bazel-test.sh
@@ -42,7 +42,7 @@ cat generator-versions.json
 # try generating the google/example/library/v1 ruby gapic library
 bazelisk build //google/example/library/v1:google-cloud-example-library-v1-ruby
 
-# try generating the google/ads/googleads/v21 ruby gapic library
-bazelisk build //google/ads/googleads/v21:googleads-ruby
+# try generating the google/ads/googleads/v25 ruby gapic library
+bazelisk build //google/ads/googleads/v25:googleads-ruby
 
 popd


### PR DESCRIPTION
Updates the Bazel Google Ads generation target in `.kokoro/bazel-test.sh` from deprecated `v21` to active `v25` to fix presubmit failures caused by upstream removal in `googleapis/googleapis`.

Related:
- https://github.com/googleapis/gapic-generator-ruby/pull/1337#issuecomment-5499580994