### PR TITLE
fix(generator): rejoin split doc URLs and strip non-existent message links

### DIFF
--- a/gapic-generator/lib/gapic/formatting_utils.rb
+++ b/gapic-generator/lib/gapic/formatting_utils.rb
@@ -32,6 +32,13 @@ module Gapic
       "version", "yield", "yieldparam", "yieldreturn"
     ].freeze
 
+    # Non-existent messages referenced in proto documentation comments (b/158466893).
+    # Cross-references to these messages (or their fields) cannot be resolved, so the links
+    # are stripped to avoid broken documentation references.
+    @non_existent_messages = [
+      "google.cloud.automl.v1.ColumnSpec"
+    ].freeze
+
     class << self
       ##
       # Given an enumerable of lines, performs yardoc formatting, including:
@@ -52,9 +59,8 @@ module Gapic
       #
       def format_doc_lines api, lines, disable_xrefs: false, transport: nil
         transport ||= api&.default_transport || :grpc
-        # Tracks fenced blocks, multiline inline code spans, and indented code blocks.
-        in_fence = false
-        in_code_span = false
+        lines = rejoin_split_urls lines
+        in_fence = in_code_span = false
         in_block = nil
         base_indent = 0
         (lines - @omit_lines).map do |line|
@@ -98,6 +104,21 @@ module Gapic
       end
 
       private
+
+      def rejoin_split_urls lines
+        return lines if lines.empty?
+
+        # Fix for misformatted markdown links across line breaks (b/153077040).
+        # Callers may pass lines with trailing newlines (e.g., from String#each_line in schema wrappers)
+        # or without trailing newlines (e.g., from String#split("\n") in GemPresenter#readme_description).
+        # We must preserve the presence or absence of trailing newlines on each element.
+        has_newlines = lines.any? { |l| l.end_with? "\n" }
+        if has_newlines
+          lines.join.gsub(%r{https:\n\s*//}, "https://").each_line.to_a
+        else
+          lines.join("\n").gsub(%r{https:\n\s*//}, "https://").split("\n", -1)
+        end
+      end
 
       def update_indent_state in_block, base_indent, line, indent
         if in_block != true && @list_element_detector =~ line
@@ -155,6 +176,12 @@ module Gapic
 
       def format_line_xrefs api, line, disable_xrefs, transport
         while (m = @xref_detector.match line)
+          # Remove links to known non-existent messages (b/158466893)
+          if @non_existent_messages.any? { |msg| m[:addr] == msg || m[:addr].start_with?("#{msg}.") }
+            line = "#{m[:pre]}#{m[:text]}#{m[:post]}"
+            next
+          end
+
           entity = api.lookup m[:addr]
           is_mixin_field_addr = Gapic::Model::Mixins.mixin_message_field_address?(
             m[:addr],

--- a/gapic-generator/test/gapic/formatting_utils_test.rb
+++ b/gapic-generator/test/gapic/formatting_utils_test.rb
@@ -723,4 +723,50 @@ class FormattingUtilsTest < Minitest::Test
       "New paragraph with \\\\{100, 200}\n"
     ], result
   end
+
+  def test_format_doc_lines_rejoin_split_urls
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
+      "[`google.rpc.Status`](https:\n",
+      "//github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)\n"
+    ]
+    assert_equal [
+      "[`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)\n"
+    ], result
+  end
+
+  def test_format_doc_lines_rejoin_split_urls_without_trailing_newlines
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
+      "[`google.rpc.Status`](https:",
+      "//github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)"
+    ]
+    assert_equal [
+      "[`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)"
+    ], result
+  end
+
+  def test_format_doc_lines_without_trailing_newlines_preserves_lines
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
+      "## Overview",
+      "",
+      "Typical Garbage Service overview.",
+      "",
+      "## Resources"
+    ]
+    assert_equal [
+      "## Overview",
+      "",
+      "Typical Garbage Service overview.",
+      "",
+      "## Resources"
+    ], result
+  end
+
+  def test_format_doc_lines_non_existent_messages
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
+      "The column names must contain [display_name-s][google.cloud.automl.v1.ColumnSpec.display_name]!\n"
+    ]
+    assert_equal [
+      "The column names must contain display_name-s!\n"
+    ], result
+  end
 end


### PR DESCRIPTION
### Summary
- Rejoin doc URLs split across line breaks (e.g., `https:\n //...` -> `https://...`), addressing internal issue b/153077040.
- Strip cross-reference links for known non-existent messages (`@non_existent_messages`, currently including `google.cloud.automl.v1.ColumnSpec`), addressing internal issue b/158466893.

### Verification
- Built `gapic-generator` gem locally and verified generation across all libraries in `googleapis/google-cloud-ruby` via Librarian.
- Confirmed `google-cloud-automl-v1` and `google-cloud-automl-v1beta1` generate clean docs without dangling links or split URLs in onboarding PR https://github.com/googleapis/google-cloud-ruby/pull/36511.
- Resolves https://github.com/googleapis/librarian/issues/7465.
- Ran `toys ci --test --rubocop --doctest` and `toys ci --yard` (0 errors, 0 warnings).