### PR TITLE
chore(ci): use YOSHI_CODE_BOT_TOKEN for tag generator workflow

### DIFF
--- a/.github/workflows/tag-generators.yml
+++ b/.github/workflows/tag-generators.yml
@@ -17,15 +17,16 @@ jobs:
     if: ${{ github.repository == 'googleapis/gapic-generator-ruby' }}
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     permissions:
       contents: write
       packages: read
     steps:
       - name: Checkout repo
+        # zizmor: ignore[artipacked] - checkout v6 persists credentials safely in RUNNER_TEMP
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       - name: Install Ruby 3.4
         uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1.315.0
         with:


### PR DESCRIPTION
### Summary

Let's use `YOSHI_CODE_BOT_TOKEN` instead of `GITHUB_TOKEN` for the tag generator release workflow now that repository permissions for `yoshi-code-bot` have been configured.

### Context & Motivation

- #1291 originally switched the token to `YOSHI_CODE_BOT_TOKEN` so that release tags pushed by the workflow could trigger downstream release workflows (which GitHub Actions restricts when using the default `GITHUB_TOKEN`).
- #1321 temporarily switched back to `GITHUB_TOKEN` because `yoshi-code-bot` lacked write permissions at the time and failed with HTTP 403.
- The repository permissions for `yoshi-code-bot` have now been configured, enabling the workflow to use `YOSHI_CODE_BOT_TOKEN` as originally intended.